### PR TITLE
test(compiler): add coverage for route_splitting.rs (0% → 95%+)

### DIFF
--- a/native/vertz-compiler-core/src/route_splitting.rs
+++ b/native/vertz-compiler-core/src/route_splitting.rs
@@ -747,3 +747,984 @@ fn cleanup_imports(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn transform(source: &str) -> String {
+        let allocator = Allocator::default();
+        let source_type = SourceType::tsx();
+        let parser = Parser::new(&allocator, source, source_type);
+        let parsed = parser.parse();
+        let mut ms = crate::magic_string::MagicString::new(source);
+        transform_route_splitting(&mut ms, &parsed.program, source);
+        ms.to_string()
+    }
+
+    // ── Fast bail-out paths ──────────────────────────────────────────
+
+    #[test]
+    fn no_define_routes_call_in_source_returns_unchanged() {
+        let source = r#"import { something } from "@vertz/ui";
+const x = 1;"#;
+        assert_eq!(transform(source), source);
+    }
+
+    #[test]
+    fn define_routes_not_imported_from_vertz_returns_unchanged() {
+        let source = r#"import { defineRoutes } from "some-other-lib";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        assert_eq!(transform(source), source);
+    }
+
+    #[test]
+    fn define_routes_string_in_comment_but_no_actual_call_returns_unchanged() {
+        // Source contains "defineRoutes(" as a string but no actual import
+        let source = r#"// defineRoutes( is used for routing
+const x = 1;"#;
+        assert_eq!(transform(source), source);
+    }
+
+    #[test]
+    fn empty_define_routes_object_returns_unchanged() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+defineRoutes({});"#;
+        assert_eq!(transform(source), source);
+    }
+
+    #[test]
+    fn define_routes_with_no_arguments_returns_unchanged() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+defineRoutes();"#;
+        assert_eq!(transform(source), source);
+    }
+
+    #[test]
+    fn define_routes_with_non_object_argument_returns_unchanged() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+const config = {};
+defineRoutes(config);"#;
+        assert_eq!(transform(source), source);
+    }
+
+    // ── Vertz import source variants ─────────────────────────────────
+
+    #[test]
+    fn import_from_vertz_ui_is_recognized() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "should lazify: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn import_from_vertz_ui_router_is_recognized() {
+        let source = r#"import { defineRoutes } from "@vertz/ui/router";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "should lazify: {}",
+            result
+        );
+    }
+
+    // ── Basic lazification ───────────────────────────────────────────
+
+    #[test]
+    fn default_import_lazified_with_m_default() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains(
+                "() => import('./pages/Home').then(m => ({ default: () => m.default() }))"
+            ),
+            "default import should use m.default: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn named_import_lazified_with_m_export_name() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import { Dashboard } from "./pages/Dashboard";
+const routes = defineRoutes({
+  "/dash": { component: () => Dashboard() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains(
+                "() => import('./pages/Dashboard').then(m => ({ default: () => m.Dashboard() }))"
+            ),
+            "named import should use m.Dashboard: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn aliased_named_import_lazified_with_original_export_name() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import { Dashboard as Dash } from "./pages/Dashboard";
+const routes = defineRoutes({
+  "/dash": { component: () => Dash() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("m.Dashboard()"),
+            "should use original export name: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn relative_parent_import_is_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Settings from "../Settings";
+const routes = defineRoutes({
+  "/settings": { component: () => Settings() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('../Settings')"),
+            "parent-relative import should be lazified: {}",
+            result
+        );
+    }
+
+    // ── Non-relative imports are NOT lazified ────────────────────────
+
+    #[test]
+    fn package_import_not_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import SomePage from "some-package";
+const routes = defineRoutes({
+  "/": { component: () => SomePage() },
+});"#;
+        let result = transform(source);
+        // SomePage not in import map → factory not rewritten
+        assert!(
+            result.contains("() => SomePage()"),
+            "package import should not be lazified: {}",
+            result
+        );
+    }
+
+    // ── Multiple routes ──────────────────────────────────────────────
+
+    #[test]
+    fn multiple_routes_each_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+import About from "./pages/About";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+  "/about": { component: () => About() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "Home should be lazified: {}",
+            result
+        );
+        assert!(
+            result.contains("import('./pages/About')"),
+            "About should be lazified: {}",
+            result
+        );
+    }
+
+    // ── Nested children routes ───────────────────────────────────────
+
+    #[test]
+    fn nested_children_routes_are_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Layout from "./Layout";
+import Home from "./pages/Home";
+import Profile from "./pages/Profile";
+const routes = defineRoutes({
+  "/": {
+    component: () => Layout(),
+    children: {
+      "/home": { component: () => Home() },
+      "/profile": { component: () => Profile() },
+    },
+  },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./Layout')"),
+            "Layout should be lazified: {}",
+            result
+        );
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "Home should be lazified: {}",
+            result
+        );
+        assert!(
+            result.contains("import('./pages/Profile')"),
+            "Profile should be lazified: {}",
+            result
+        );
+    }
+
+    // ── Factory shapes that are NOT transformed ──────────────────────
+
+    #[test]
+    fn non_arrow_factory_not_transformed() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: Home },
+});"#;
+        let result = transform(source);
+        // Not an arrow function, so not transformed
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "non-arrow should not be lazified: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn arrow_with_block_body_not_transformed() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => { return Home(); } },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "block-body arrow should not be lazified: {}",
+            result
+        );
+    }
+
+    // ── Symbol used elsewhere prevents lazification ──────────────────
+
+    #[test]
+    fn symbol_used_elsewhere_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+console.log(Home);
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol used elsewhere should not be lazified: {}",
+            result
+        );
+        // Import should remain since symbol is still used
+        assert!(
+            result.contains("import Home from"),
+            "import should remain: {}",
+            result
+        );
+    }
+
+    // ── Import cleanup ───────────────────────────────────────────────
+
+    #[test]
+    fn entire_import_removed_when_all_symbols_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import Home from"),
+            "import should be removed: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn partial_import_keeps_remaining_named_specifiers() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import { Dashboard, helper } from "./pages/Dashboard";
+const routes = defineRoutes({
+  "/dash": { component: () => Dashboard() },
+});
+console.log(helper);"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Dashboard')"),
+            "Dashboard should be lazified: {}",
+            result
+        );
+        // helper is used elsewhere, so the import should be rebuilt with just helper
+        assert!(
+            result.contains("{ helper }"),
+            "helper should remain in import: {}",
+            result
+        );
+        assert!(
+            !result.contains("{ Dashboard,") && !result.contains("{ Dashboard }"),
+            "Dashboard should be removed from import specifiers: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn partial_import_keeps_default_when_named_removed() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Layout, { Child } from "./Layout";
+const routes = defineRoutes({
+  "/": {
+    component: () => Layout(),
+    children: {
+      "/child": { component: () => Child() },
+    },
+  },
+});
+"#;
+        let result = transform(source);
+        // Both Layout and Child should be lazified since they're only used in factories
+        assert!(
+            result.contains("import('./Layout')"),
+            "should lazify: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn import_trailing_newline_removed_with_entire_declaration() {
+        let source = "import { defineRoutes } from \"@vertz/ui\";\nimport Home from \"./pages/Home\";\nconst routes = defineRoutes({\n  \"/\": { component: () => Home() },\n});";
+        let result = transform(source);
+        // Should not have double newlines where the import was
+        assert!(
+            !result.contains("import Home"),
+            "import should be removed: {}",
+            result
+        );
+    }
+
+    // ── defineRoutes in different statement contexts ──────────────────
+
+    #[test]
+    fn define_routes_in_expression_statement() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "expression statement should work: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn define_routes_in_export_named_declaration() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+export const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "export named should work: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn define_routes_in_export_default_declaration() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+export default defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "export default should work: {}",
+            result
+        );
+    }
+
+    // ── Property name variants ───────────────────────────────────────
+
+    #[test]
+    fn string_literal_component_key_is_recognized() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { "component": () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "string key 'component' should work: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn non_component_property_not_transformed() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import guard from "./guard";
+const routes = defineRoutes({
+  "/": { guard: () => guard(), component: () => null },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("() => guard()"),
+            "guard property should not be transformed: {}",
+            result
+        );
+    }
+
+    // ── Namespace import is skipped ──────────────────────────────────
+
+    #[test]
+    fn namespace_import_not_added_to_import_map() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import * as pages from "./pages";
+const routes = defineRoutes({
+  "/": { component: () => pages.Home() },
+});"#;
+        let result = transform(source);
+        // Member expression callee is not an Identifier, so it's skipped
+        assert!(
+            result.contains("pages.Home()"),
+            "namespace should not be lazified: {}",
+            result
+        );
+    }
+
+    // ── Symbol used in various expression contexts ───────────────────
+
+    #[test]
+    fn symbol_used_in_variable_init_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const alias = Home;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol used in variable should not be lazified: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_used_in_jsx_element_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const el = <Home />;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol used in JSX should not be lazified: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_in_conditional_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const x = true ? Home : null;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in conditional should prevent lazification: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_in_binary_expr_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const x = Home || null;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in logical expr should prevent lazification: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_in_template_literal_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const x = `${Home}`;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in template literal should prevent lazification: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_in_object_value_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const map = { home: Home };
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in object value should prevent lazification: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_in_assignment_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+let x;
+x = Home;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in assignment should prevent lazification: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_in_call_arg_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+register(Home);
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol as call argument should prevent lazification: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn symbol_as_callee_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+Home();
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol as callee outside factory should prevent lazification: {}",
+            result
+        );
+    }
+
+    // ── Import declaration usage is NOT counted as "used elsewhere" ──
+
+    #[test]
+    fn import_declaration_not_counted_as_external_usage() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        // The import statement itself should not count as "used elsewhere"
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "import decl should not count as usage: {}",
+            result
+        );
+    }
+
+    // ── Route config value not an object → skip ──────────────────────
+
+    #[test]
+    fn route_value_not_object_is_skipped() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const homeRoute = { component: () => Home() };
+const routes = defineRoutes({
+  "/": homeRoute,
+});"#;
+        let result = transform(source);
+        // homeRoute is an identifier, not an object literal → skipped
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "non-object route value should be skipped: {}",
+            result
+        );
+    }
+
+    // ── Spread properties are skipped ────────────────────────────────
+
+    #[test]
+    fn spread_property_in_route_object_is_skipped() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const base = {};
+const routes = defineRoutes({
+  ...base,
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        // Spread at top level → ObjectPropertyKind::SpreadProperty, skipped
+        // But the "/" route should still be processed
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "normal route after spread should still work: {}",
+            result
+        );
+    }
+
+    // ── Full compile integration ─────────────────────────────────────
+
+    #[test]
+    fn full_compile_with_route_splitting_enabled() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+import About from "./pages/About";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+  "/about": { component: () => About() },
+});"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("routes.ts".to_string()),
+                route_splitting: Some(true),
+                ..Default::default()
+            },
+        );
+        assert!(
+            result.code.contains("import('./pages/Home')"),
+            "Home should be lazified in full compile: {}",
+            result.code
+        );
+        assert!(
+            result.code.contains("import('./pages/About')"),
+            "About should be lazified in full compile: {}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("import Home from"),
+            "static Home import should be removed: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn full_compile_without_route_splitting_flag_does_not_transform() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = crate::compile(
+            source,
+            crate::CompileOptions {
+                filename: Some("routes.ts".to_string()),
+                route_splitting: Some(false),
+                ..Default::default()
+            },
+        );
+        assert!(
+            !result.code.contains("import('./pages/Home')"),
+            "should not transform without flag: {}",
+            result.code
+        );
+    }
+
+    // ── Cleanup: rebuilds import with aliased remaining specifier ─────
+
+    #[test]
+    fn partial_cleanup_preserves_alias() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import { Page as MyPage, helper as h } from "./pages/utils";
+const routes = defineRoutes({
+  "/": { component: () => MyPage() },
+});
+console.log(h);"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/utils')"),
+            "MyPage should be lazified: {}",
+            result
+        );
+        // helper was aliased as h, should be preserved as "helper as h"
+        assert!(
+            result.contains("helper as h"),
+            "alias should be preserved: {}",
+            result
+        );
+    }
+
+    // ── Parenthesized expression in usage check ──────────────────────
+
+    #[test]
+    fn symbol_in_parenthesized_expr_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const x = (Home);
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in parens should prevent lazification: {}",
+            result
+        );
+    }
+
+    // ── Member expression in usage check ─────────────────────────────
+
+    #[test]
+    fn symbol_in_member_expression_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const name = Home.displayName;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in member expr should prevent lazification: {}",
+            result
+        );
+    }
+
+    // ── Arrow in usage check ─────────────────────────────────────────
+
+    #[test]
+    fn symbol_in_non_factory_arrow_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const fn = () => { Home(); };
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol in non-factory arrow should prevent lazification: {}",
+            result
+        );
+    }
+
+    // ── Export named with defineRoutes ────────────────────────────────
+
+    #[test]
+    fn export_named_variable_with_define_routes() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+export const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "export named const should work: {}",
+            result
+        );
+    }
+
+    // ── defineRoutes call that's not actually defineRoutes ────────────
+
+    #[test]
+    fn call_expression_not_named_define_routes_is_ignored() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = createRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        // createRoutes is not defineRoutes → no transform
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "non-defineRoutes call should not transform: {}",
+            result
+        );
+    }
+
+    // ── Import without specifiers ────────────────────────────────────
+
+    #[test]
+    fn side_effect_import_without_specifiers_ignored() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import "./styles.css";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "should still lazify Home: {}",
+            result
+        );
+        assert!(
+            result.contains("import \"./styles.css\""),
+            "side-effect import should remain: {}",
+            result
+        );
+    }
+
+    // ── Multiple specifiers from same declaration, all lazified ──────
+
+    #[test]
+    fn all_specifiers_from_one_import_lazified_removes_entire_import() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import { Home, About } from "./pages";
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+  "/about": { component: () => About() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import { Home"),
+            "entire import should be removed: {}",
+            result
+        );
+        assert!(
+            result.contains("import('./pages')"),
+            "should lazify both: {}",
+            result
+        );
+    }
+
+    // ── JSX element as factory body ──────────────────────────────────
+
+    #[test]
+    fn jsx_element_factory_with_uppercase_component_is_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const routes = defineRoutes({
+  "/": { component: () => <Home /> },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "JSX element with uppercase component should be lazified: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn jsx_element_with_lowercase_tag_not_lazified() {
+        // Lowercase tag name = HTML element, not a component
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+const routes = defineRoutes({
+  "/": { component: () => <div /> },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("<div />"),
+            "lowercase JSX tag should not be lazified: {}",
+            result
+        );
+    }
+
+    // ── Non-Identifier callee in factory ─────────────────────────────
+
+    #[test]
+    fn member_expression_callee_in_factory_not_lazified() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import * as pages from "./pages";
+const routes = defineRoutes({
+  "/": { component: () => pages.Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("pages.Home()"),
+            "member expression callee should not be lazified: {}",
+            result
+        );
+    }
+
+    // ── Spread property inside route config is skipped ───────────────
+
+    #[test]
+    fn spread_inside_route_config_is_skipped() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+const baseConfig = { guard: true };
+const routes = defineRoutes({
+  "/": { ...baseConfig, component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            result.contains("import('./pages/Home')"),
+            "component after spread in config should still work: {}",
+            result
+        );
+    }
+
+    // ── Symbol used in export named with variable decl ───────────────
+
+    #[test]
+    fn symbol_in_export_named_var_prevents_lazification() {
+        let source = r#"import { defineRoutes } from "@vertz/ui";
+import Home from "./pages/Home";
+export const comp = Home;
+const routes = defineRoutes({
+  "/": { component: () => Home() },
+});"#;
+        let result = transform(source);
+        assert!(
+            !result.contains("import('./pages/Home')"),
+            "symbol exported separately should prevent lazification: {}",
+            result
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 55 unit tests for `vertz-compiler-core/src/route_splitting.rs` which previously had 0% test coverage
- Covers all public and internal code paths: bail-outs, lazification, import cleanup, symbol usage detection, JSX handling, nested routes, and full compile integration
- All quality gates pass: `cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check`

Closes #4

## Public API Changes

None — tests only.

## Test plan

- [x] All 55 new tests pass
- [x] All existing tests still pass (79 total across all crates)
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)