### PR TITLE
test(compiler): add 120 tests for lib.rs orchestration and 5 modules

### DIFF
--- a/native/vertz-compiler-core/src/body_jsx_diagnostics.rs
+++ b/native/vertz-compiler-core/src/body_jsx_diagnostics.rs
@@ -153,3 +153,113 @@ impl<'a, 'b> Visit<'b> for JsxCollector<'a> {
         oxc_ast_visit::walk::walk_jsx_fragment(self, frag);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> Vec<crate::Diagnostic> {
+        let result = compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        result.diagnostics.unwrap_or_default()
+    }
+
+    fn has_body_jsx_diagnostic(diagnostics: &[crate::Diagnostic]) -> bool {
+        diagnostics
+            .iter()
+            .any(|d| d.message.contains("[jsx-outside-tree]"))
+    }
+
+    // ── JSX in return → no diagnostic ──────────────────────────────
+
+    #[test]
+    fn no_diagnostic_for_jsx_in_return() {
+        let diagnostics = compile_tsx(
+            r#"function App() {
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(!has_body_jsx_diagnostic(&diagnostics));
+    }
+
+    // ── JSX outside return → diagnostic ────────────────────────────
+
+    #[test]
+    fn diagnostic_for_jsx_outside_return() {
+        let diagnostics = compile_tsx(
+            r#"function App() {
+    const el = <span>outside</span>;
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(has_body_jsx_diagnostic(&diagnostics));
+    }
+
+    // ── JSX in nested function → no diagnostic ─────────────────────
+
+    #[test]
+    fn no_diagnostic_for_jsx_in_arrow_function() {
+        let diagnostics = compile_tsx(
+            r#"function App() {
+    const render = () => <span>nested</span>;
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(!has_body_jsx_diagnostic(&diagnostics));
+    }
+
+    #[test]
+    fn no_diagnostic_for_jsx_in_function_expression() {
+        let diagnostics = compile_tsx(
+            r#"function App() {
+    const render = function() { return <span>nested</span>; };
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(!has_body_jsx_diagnostic(&diagnostics));
+    }
+
+    // ── JSX fragment outside return → diagnostic ───────────────────
+
+    #[test]
+    fn diagnostic_for_fragment_outside_return() {
+        let diagnostics = compile_tsx(
+            r#"function App() {
+    const el = <><span>frag</span></>;
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(has_body_jsx_diagnostic(&diagnostics));
+    }
+
+    // ── Diagnostic has line/column info ─────────────────────────────
+
+    #[test]
+    fn diagnostic_includes_line_and_column() {
+        let diagnostics = compile_tsx(
+            r#"function App() {
+    const el = <span>outside</span>;
+    return <div>Hello</div>;
+}"#,
+        );
+        let diag = diagnostics
+            .iter()
+            .find(|d| d.message.contains("[jsx-outside-tree]"))
+            .unwrap();
+        assert!(diag.line.is_some());
+        assert!(diag.column.is_some());
+    }
+
+    // ── No component → no diagnostics ──────────────────────────────
+
+    #[test]
+    fn no_diagnostic_when_no_component() {
+        let diagnostics = compile_tsx("const x = 1;");
+        assert!(!has_body_jsx_diagnostic(&diagnostics));
+    }
+}

--- a/native/vertz-compiler-core/src/import_injection.rs
+++ b/native/vertz-compiler-core/src/import_injection.rs
@@ -292,3 +292,291 @@ pub fn inject_imports(ms: &mut MagicString, target: &str) {
     let import_block = format!("{}\n", import_lines.join("\n"));
     ms.prepend(&import_block);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::magic_string::MagicString;
+
+    fn inject(code: &str) -> String {
+        let mut ms = MagicString::new(code);
+        inject_imports(&mut ms, "dom");
+        ms.to_string()
+    }
+
+    fn inject_with_target(code: &str, target: &str) -> String {
+        let mut ms = MagicString::new(code);
+        inject_imports(&mut ms, target);
+        ms.to_string()
+    }
+
+    // ── No imports needed ──────────────────────────────────────────
+
+    #[test]
+    fn no_imports_when_no_helpers_used() {
+        let result = inject("const x = 1;");
+        assert_eq!(result, "const x = 1;");
+    }
+
+    // ── Runtime feature imports ────────────────────────────────────
+
+    #[test]
+    fn injects_signal_import() {
+        let result = inject("signal(0);");
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn injects_computed_import() {
+        let result = inject("computed(() => x);");
+        assert!(result.contains("import { computed } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn injects_effect_import() {
+        let result = inject("effect(() => {});");
+        assert!(result.contains("import { effect } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn injects_batch_import() {
+        let result = inject("batch(() => {});");
+        assert!(result.contains("import { batch } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn injects_untrack_import() {
+        let result = inject("untrack(() => x);");
+        assert!(result.contains("import { untrack } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn injects_multiple_runtime_imports_sorted() {
+        let result = inject("effect(() => {}); signal(0);");
+        assert!(result.contains("import { effect, signal } from '@vertz/ui';"));
+    }
+
+    // ── DOM helper imports ─────────────────────────────────────────
+
+    #[test]
+    fn injects_dom_helper_import() {
+        let result = inject("__element('div');");
+        assert!(result.contains("import { __element } from '@vertz/ui/internals';"));
+    }
+
+    #[test]
+    fn injects_multiple_dom_helpers_sorted() {
+        let result = inject("__element('div'); __append(el, child);");
+        assert!(result.contains("import { __append, __element } from '@vertz/ui/internals';"));
+    }
+
+    #[test]
+    fn injects_both_runtime_and_dom_imports() {
+        let result = inject("signal(0); __element('div');");
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+        assert!(result.contains("import { __element } from '@vertz/ui/internals';"));
+    }
+
+    // ── TUI target ─────────────────────────────────────────────────
+
+    #[test]
+    fn tui_target_uses_tui_internals_path() {
+        let result = inject_with_target("__element('div');", "tui");
+        assert!(result.contains("from '@vertz/tui/internals'"));
+    }
+
+    #[test]
+    fn dom_target_uses_ui_internals_path() {
+        let result = inject_with_target("__element('div');", "dom");
+        assert!(result.contains("from '@vertz/ui/internals'"));
+    }
+
+    // ── Existing bindings are skipped ──────────────────────────────
+
+    #[test]
+    fn skips_import_when_already_imported() {
+        let code = "import { signal } from './my-signal';\nsignal(0);";
+        let result = inject(code);
+        assert!(
+            !result.contains("from '@vertz/ui'"),
+            "should not inject import for existing binding"
+        );
+    }
+
+    #[test]
+    fn skips_import_for_locally_declared_function() {
+        let code = "function signal() {}\nsignal(0);";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui'"));
+    }
+
+    #[test]
+    fn skips_import_for_const_declaration() {
+        let code = "const signal = () => {};\nsignal(0);";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui'"));
+    }
+
+    #[test]
+    fn skips_import_for_export_function() {
+        let code = "export function __element() {}\n__element('div');";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui/internals'"));
+    }
+
+    #[test]
+    fn skips_import_for_aliased_import() {
+        let code = "import { foo as signal } from './x';\nsignal(0);";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui'"));
+    }
+
+    #[test]
+    fn skips_import_for_multiline_import() {
+        let code = "import {\n  signal,\n  computed\n} from './x';\nsignal(0); computed(() => x);";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui'"));
+    }
+
+    // ── Comment stripping ──────────────────────────────────────────
+
+    #[test]
+    fn does_not_detect_helper_in_line_comment() {
+        let code = "// signal(0)";
+        let result = inject(code);
+        assert_eq!(result, code);
+    }
+
+    #[test]
+    fn does_not_detect_helper_in_block_comment() {
+        let code = "/* __element('div') */";
+        let result = inject(code);
+        assert_eq!(result, code);
+    }
+
+    #[test]
+    fn does_not_detect_helper_in_jsdoc_comment() {
+        let code = "/** __child(el, 0) */";
+        let result = inject(code);
+        assert_eq!(result, code);
+    }
+
+    // ── String literal handling ───────────────────────────────────
+    // Note: strip_comments preserves string content (only strips comments),
+    // so helpers inside strings ARE detected as used. This is a known
+    // trade-off: false positives from strings are harmless (extra import),
+    // while false negatives from comments could cause runtime errors.
+
+    #[test]
+    fn detects_helper_in_string_literal() {
+        // Strings are NOT stripped — helper pattern in string IS detected
+        let code = "const x = 'signal(0)';";
+        let result = inject(code);
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+
+    // ── All DOM helpers detected ───────────────────────────────────
+
+    #[test]
+    fn detects_all_dom_helpers() {
+        for helper in DOM_HELPERS {
+            let code = format!("{}(arg);", helper);
+            let result = inject(&code);
+            assert!(
+                result.contains(helper),
+                "expected '{}' to be detected as DOM helper",
+                helper
+            );
+        }
+    }
+
+    // ── All runtime features detected ──────────────────────────────
+
+    #[test]
+    fn detects_all_runtime_features() {
+        for feature in RUNTIME_FEATURES {
+            let code = format!("{}(arg);", feature);
+            let result = inject(&code);
+            assert!(
+                result.contains(feature),
+                "expected '{}' to be detected as runtime feature",
+                feature
+            );
+        }
+    }
+
+    // ── Existing binding edge cases ────────────────────────────────
+
+    #[test]
+    fn skips_type_import() {
+        let code = "import type { Foo } from './x';\nsignal(0);";
+        let result = inject(code);
+        // type import should NOT block signal injection
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn skips_let_declaration() {
+        let code = "let __element = null;\n__element('div');";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui/internals'"));
+    }
+
+    #[test]
+    fn skips_var_declaration() {
+        let code = "var __element = null;\n__element('div');";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui/internals'"));
+    }
+
+    #[test]
+    fn skips_export_const_declaration() {
+        let code = "export const signal = () => {};\nsignal(0);";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui'"));
+    }
+
+    #[test]
+    fn skips_export_let_declaration() {
+        let code = "export let signal = () => {};\nsignal(0);";
+        let result = inject(code);
+        assert!(!result.contains("from '@vertz/ui'"));
+    }
+
+    // ── Escaped strings in strip_comments ──────────────────────────
+
+    #[test]
+    fn handles_escaped_quote_in_string() {
+        let code = r#"const x = "test \"signal(0)\" end"; signal(1);"#;
+        let result = inject(code);
+        // The real signal(1) call should be detected
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+
+    // ── Destructuring skipped in binding collection ────────────────
+
+    #[test]
+    fn destructuring_const_does_not_block_import() {
+        let code = "const { x } = obj;\nsignal(0);";
+        let result = inject(code);
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+
+    #[test]
+    fn array_destructuring_does_not_block_import() {
+        let code = "const [x] = arr;\nsignal(0);";
+        let result = inject(code);
+        // Array destructuring is skipped in binding collection
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+
+    // ── Import not at line start is ignored ─────────────────────────
+
+    #[test]
+    fn import_not_at_line_start_is_not_collected() {
+        // x import { signal } from ... — not at start of line
+        let code = "x import { signal } from './x';\nsignal(0);";
+        let result = inject(code);
+        assert!(result.contains("import { signal } from '@vertz/ui';"));
+    }
+}

--- a/native/vertz-compiler-core/src/lib.rs
+++ b/native/vertz-compiler-core/src/lib.rs
@@ -656,3 +656,481 @@ fn build_manifest_registry(options: &CompileOptions) -> reactivity_analyzer::Man
 
     registry
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_opts() -> CompileOptions {
+        CompileOptions {
+            filename: Some("test.tsx".to_string()),
+            ..Default::default()
+        }
+    }
+
+    // ── Basic compilation ──────────────────────────────────────────
+
+    #[test]
+    fn compile_returns_code_with_header() {
+        let result = compile("const x = 1;", default_opts());
+        assert!(result.code.starts_with("// compiled by vertz-native\n"));
+    }
+
+    #[test]
+    fn compile_simple_component() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        assert!(result.code.contains("// compiled by vertz-native"));
+        assert!(result.components.is_some());
+        let comps = result.components.unwrap();
+        assert_eq!(comps.len(), 1);
+        assert_eq!(comps[0].name, "App");
+    }
+
+    #[test]
+    fn compile_returns_source_map() {
+        let result = compile("const x = 1;", default_opts());
+        assert!(result.map.is_some());
+    }
+
+    // ── Parser errors ──────────────────────────────────────────────
+
+    #[test]
+    fn compile_returns_diagnostics_for_parser_errors() {
+        let result = compile("function {", default_opts());
+        assert!(result.diagnostics.is_some());
+        let diags = result.diagnostics.unwrap();
+        assert!(!diags.is_empty());
+        assert!(diags[0].line.is_some());
+        assert!(diags[0].column.is_some());
+    }
+
+    #[test]
+    fn compile_with_parser_error_returns_original_source_with_header() {
+        let source = "function {";
+        let result = compile(source, default_opts());
+        assert!(result.code.contains(source));
+    }
+
+    // ── Component info output ──────────────────────────────────────
+
+    #[test]
+    fn component_info_includes_variables() {
+        let result = compile(
+            r#"import { signal } from '@vertz/ui';
+function App() {
+    const count = signal(0);
+    return <div>{count.value}</div>;
+}"#,
+            default_opts(),
+        );
+        let comps = result.components.unwrap();
+        assert_eq!(comps.len(), 1);
+        let vars = comps[0].variables.as_ref().unwrap();
+        assert!(!vars.is_empty());
+    }
+
+    #[test]
+    fn component_info_has_body_positions() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        let comps = result.components.unwrap();
+        assert!(comps[0].body_start > 0);
+        assert!(comps[0].body_end > comps[0].body_start);
+    }
+
+    // ── Multiple components ────────────────────────────────────────
+
+    #[test]
+    fn compile_multiple_components() {
+        let result = compile(
+            r#"function App() { return <div>App</div>; }
+function Card() { return <span>Card</span>; }"#,
+            default_opts(),
+        );
+        let comps = result.components.unwrap();
+        assert_eq!(comps.len(), 2);
+    }
+
+    // ── No components ──────────────────────────────────────────────
+
+    #[test]
+    fn compile_no_components() {
+        let result = compile("const x = 1;", default_opts());
+        let comps = result.components.unwrap();
+        assert!(comps.is_empty());
+    }
+
+    // ── fast_refresh option ────────────────────────────────────────
+
+    #[test]
+    fn fast_refresh_injects_code() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                fast_refresh: Some(true),
+                ..Default::default()
+            },
+        );
+        // Fast refresh should inject some registration code
+        assert!(
+            result.code.contains("__$fr") || result.code.contains("__$refreshReg"),
+            "fast refresh should inject code: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn no_fast_refresh_by_default() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        assert!(
+            !result.code.contains("__$fr"),
+            "should not have fast refresh by default"
+        );
+    }
+
+    // ── field_selection option ──────────────────────────────────────
+
+    #[test]
+    fn field_selection_returns_data_when_enabled() {
+        let result = compile(
+            r#"const tasks = query(api.tasks.list());
+function App() { return <div>{tasks.data.name}</div>; }"#,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                field_selection: Some(true),
+                ..Default::default()
+            },
+        );
+        assert!(result.field_selections.is_some());
+        let sels = result.field_selections.unwrap();
+        assert!(!sels.is_empty());
+        assert_eq!(sels[0].query_var, "tasks");
+    }
+
+    #[test]
+    fn field_selection_none_when_disabled() {
+        let result = compile(
+            r#"const tasks = query(api.tasks.list());
+function App() { return <div>{tasks.data.name}</div>; }"#,
+            default_opts(),
+        );
+        assert!(result.field_selections.is_none());
+    }
+
+    // ── hydration_markers option ───────────────────────────────────
+
+    #[test]
+    fn hydration_markers_returns_ids_when_enabled() {
+        let result = compile(
+            r#"import { signal } from '@vertz/ui';
+function App() {
+    const count = signal(0);
+    return <div>{count.value}</div>;
+}"#,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                hydration_markers: Some(true),
+                ..Default::default()
+            },
+        );
+        // Interactive components should get hydration IDs
+        if let Some(ref ids) = result.hydration_ids {
+            assert!(!ids.is_empty());
+        }
+    }
+
+    #[test]
+    fn hydration_markers_none_when_disabled() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        assert!(result.hydration_ids.is_none());
+    }
+
+    // ── CSS extraction ─────────────────────────────────────────────
+
+    #[test]
+    fn extracts_css_from_tagged_template() {
+        let result = compile(
+            r#"const styles = css`
+.container { color: red; }
+`;
+function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        if let Some(ref css) = result.css {
+            assert!(css.contains("color: red") || css.contains("container"));
+        }
+    }
+
+    #[test]
+    fn no_css_when_none_present() {
+        let result = compile("const x = 1;", default_opts());
+        assert!(result.css.is_none());
+    }
+
+    // ── Diagnostics ────────────────────────────────────────────────
+
+    #[test]
+    fn no_diagnostics_for_clean_code() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        assert!(result.diagnostics.is_none());
+    }
+
+    // ── Source type from filename ───────────────────────────────────
+
+    #[test]
+    fn uses_tsx_source_type_for_tsx_files() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            CompileOptions {
+                filename: Some("component.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(result.diagnostics.is_none());
+    }
+
+    #[test]
+    fn uses_ts_source_type_for_ts_files() {
+        let result = compile(
+            "const x: number = 1;",
+            CompileOptions {
+                filename: Some("util.ts".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(result.diagnostics.is_none());
+    }
+
+    #[test]
+    fn defaults_filename_when_none() {
+        let result = compile(
+            "const x = 1;",
+            CompileOptions {
+                filename: None,
+                ..Default::default()
+            },
+        );
+        assert!(result.code.contains("// compiled by vertz-native"));
+    }
+
+    // ── build_manifest_registry ────────────────────────────────────
+
+    #[test]
+    fn build_manifest_registry_empty_when_no_manifests() {
+        let opts = CompileOptions::default();
+        let registry = build_manifest_registry(&opts);
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn build_manifest_registry_with_entries() {
+        let opts = CompileOptions {
+            manifests: Some(vec![ManifestEntry {
+                module_specifier: "@my/lib".to_string(),
+                export_name: "useData".to_string(),
+                reactivity_type: "signal".to_string(),
+                signal_properties: Some(vec!["value".to_string()]),
+                plain_properties: None,
+                field_signal_properties: None,
+            }]),
+            ..Default::default()
+        };
+        let registry = build_manifest_registry(&opts);
+        assert!(registry.contains_key("@my/lib"));
+        let exports = &registry["@my/lib"];
+        assert!(exports.contains_key("useData"));
+    }
+
+    // ── compile_for_ssr_aot ────────────────────────────────────────
+
+    #[test]
+    fn aot_compile_basic_component() {
+        let result = compile_for_ssr_aot(
+            r#"function App() { return <div>Hello</div>; }"#,
+            AotCompileOptions {
+                filename: Some("test.tsx".to_string()),
+            },
+        );
+        assert!(!result.components.is_empty());
+        assert_eq!(result.components[0].name, "App");
+    }
+
+    #[test]
+    fn aot_compile_returns_original_on_parse_error() {
+        let source = "function {";
+        let result = compile_for_ssr_aot(
+            source,
+            AotCompileOptions {
+                filename: Some("test.tsx".to_string()),
+            },
+        );
+        assert_eq!(result.code, source);
+        assert!(result.components.is_empty());
+    }
+
+    #[test]
+    fn aot_compile_returns_original_when_no_components() {
+        let source = "const x = 1;";
+        let result = compile_for_ssr_aot(
+            source,
+            AotCompileOptions {
+                filename: Some("test.tsx".to_string()),
+            },
+        );
+        assert_eq!(result.code, source);
+        assert!(result.components.is_empty());
+    }
+
+    #[test]
+    fn aot_compile_defaults_filename() {
+        let result = compile_for_ssr_aot(
+            r#"function App() { return <div>Hello</div>; }"#,
+            AotCompileOptions { filename: None },
+        );
+        assert!(!result.components.is_empty());
+    }
+
+    #[test]
+    fn aot_compile_component_has_tier() {
+        let result = compile_for_ssr_aot(
+            r#"function App() { return <div>Hello</div>; }"#,
+            AotCompileOptions {
+                filename: Some("test.tsx".to_string()),
+            },
+        );
+        assert!(!result.components[0].tier.is_empty());
+    }
+
+    // ── prefetch_manifest option ───────────────────────────────────
+
+    #[test]
+    fn prefetch_manifest_none_when_disabled() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            default_opts(),
+        );
+        assert!(result.extracted_routes.is_none());
+        assert!(result.extracted_queries.is_none());
+        assert!(result.route_params.is_none());
+    }
+
+    #[test]
+    fn prefetch_manifest_enabled_returns_empty_when_no_routes() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                prefetch_manifest: Some(true),
+                ..Default::default()
+            },
+        );
+        // Should return None for empty results
+        assert!(result.extracted_routes.is_none());
+    }
+
+    // ── target option ──────────────────────────────────────────────
+
+    #[test]
+    fn compile_with_tui_target() {
+        let result = compile(
+            r#"function App() { return <div>Hello</div>; }"#,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                target: Some("tui".to_string()),
+                ..Default::default()
+            },
+        );
+        // Should compile without error
+        assert!(result.code.contains("// compiled by vertz-native"));
+    }
+
+    // ── VariableInfoOutput fields ──────────────────────────────────
+
+    #[test]
+    fn variable_info_includes_kind() {
+        let result = compile(
+            r#"import { signal } from '@vertz/ui';
+function App() {
+    const count = signal(0);
+    return <div>{count.value}</div>;
+}"#,
+            default_opts(),
+        );
+        let comps = result.components.unwrap();
+        let vars = comps[0].variables.as_ref().unwrap();
+        let count_var = vars.iter().find(|v| v.name == "count");
+        assert!(count_var.is_some());
+        assert!(!count_var.unwrap().kind.is_empty());
+    }
+
+    // ── FieldSelectionOutput fields ────────────────────────────────
+
+    #[test]
+    fn field_selection_output_has_all_fields() {
+        let result = compile(
+            r#"const tasks = query(api.tasks.list());
+function App() { return <div>{tasks.data.assignee.name}</div>; }"#,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                field_selection: Some(true),
+                ..Default::default()
+            },
+        );
+        let sels = result.field_selections.unwrap();
+        assert!(!sels.is_empty());
+        assert_eq!(sels[0].query_var, "tasks");
+        assert!(!sels[0].injection_kind.is_empty());
+        assert!(!sels[0].fields.is_empty());
+        assert!(!sels[0].nested_access.is_empty());
+    }
+
+    // ── Manifest with all property types ───────────────────────────
+
+    #[test]
+    fn build_manifest_registry_with_all_properties() {
+        let opts = CompileOptions {
+            manifests: Some(vec![ManifestEntry {
+                module_specifier: "@my/lib".to_string(),
+                export_name: "useData".to_string(),
+                reactivity_type: "signal".to_string(),
+                signal_properties: Some(vec!["value".to_string()]),
+                plain_properties: Some(vec!["raw".to_string()]),
+                field_signal_properties: Some(vec!["field".to_string()]),
+            }]),
+            ..Default::default()
+        };
+        let registry = build_manifest_registry(&opts);
+        let entry = &registry["@my/lib"]["useData"];
+        assert!(entry.signal_properties.is_some());
+        assert!(entry.plain_properties.is_some());
+        assert!(entry.field_signal_properties.is_some());
+    }
+
+    // ── TypeScript stripping in pipeline ───────────────────────────
+
+    #[test]
+    fn strips_typescript_in_compilation() {
+        let result = compile(
+            r#"interface Props { title: string; }
+function App(props: Props) { return <div>{props.title}</div>; }"#,
+            default_opts(),
+        );
+        assert!(!result.code.contains("interface Props"));
+        assert!(result.diagnostics.is_none());
+    }
+}

--- a/native/vertz-compiler-core/src/mount_frame_transformer.rs
+++ b/native/vertz-compiler-core/src/mount_frame_transformer.rs
@@ -292,3 +292,232 @@ impl<'a, 'c> Visit<'c> for ArrowExprFinder<'a> {
         oxc_ast_visit::walk::walk_arrow_function_expression(self, func);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> String {
+        let result = compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        result.code
+    }
+
+    // ── Basic return with expression ───────────────────────────────
+
+    #[test]
+    fn wraps_return_with_mount_frame() {
+        let code = compile_tsx(
+            r#"function App() {
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should inject pushMountFrame: {}",
+            code
+        );
+        assert!(
+            code.contains("__flushMountFrame"),
+            "should inject flushMountFrame: {}",
+            code
+        );
+    }
+
+    #[test]
+    fn wraps_return_in_try_catch() {
+        let code = compile_tsx(
+            r#"function App() {
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(code.contains("try {"), "should have try block: {}", code);
+        assert!(
+            code.contains("__discardMountFrame"),
+            "should have discard in catch: {}",
+            code
+        );
+    }
+
+    // ── Bare return ────────────────────────────────────────────────
+
+    #[test]
+    fn handles_bare_return() {
+        let code = compile_tsx(
+            r#"function App() {
+    if (true) return;
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(
+            code.contains("__flushMountFrame"),
+            "should handle bare return: {}",
+            code
+        );
+    }
+
+    // ── Multiple returns ───────────────────────────────────────────
+
+    #[test]
+    fn handles_multiple_returns() {
+        let code = compile_tsx(
+            r#"function App() {
+    if (true) {
+        return <span>A</span>;
+    }
+    return <div>B</div>;
+}"#,
+        );
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should inject pushMountFrame: {}",
+            code
+        );
+        // Both returns should be wrapped
+        assert!(
+            code.matches("__flushMountFrame").count() >= 2,
+            "should wrap both returns: {}",
+            code
+        );
+    }
+
+    // ── Braceless if return ────────────────────────────────────────
+
+    #[test]
+    fn handles_braceless_if_return() {
+        let code = compile_tsx(
+            r#"function App() {
+    if (false) return <span>A</span>;
+    return <div>B</div>;
+}"#,
+        );
+        // Braceless returns should be wrapped in { ... }
+        assert!(
+            code.contains("__flushMountFrame"),
+            "should handle braceless return: {}",
+            code
+        );
+    }
+
+    // ── Arrow expression body ──────────────────────────────────────
+
+    #[test]
+    fn wraps_arrow_expression_body() {
+        let code = compile_tsx("const App = () => <div>Hello</div>;");
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should wrap arrow expression: {}",
+            code
+        );
+        assert!(
+            code.contains("__flushMountFrame"),
+            "should flush in arrow expression: {}",
+            code
+        );
+    }
+
+    // ── Arrow block body ───────────────────────────────────────────
+
+    #[test]
+    fn wraps_arrow_block_body() {
+        let code = compile_tsx(
+            r#"const App = () => {
+    return <div>Hello</div>;
+};"#,
+        );
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should wrap arrow block body: {}",
+            code
+        );
+    }
+
+    // ── Nested function returns are not wrapped ────────────────────
+
+    #[test]
+    fn does_not_wrap_nested_function_return() {
+        let code = compile_tsx(
+            r#"function App() {
+    const helper = () => { return 42; };
+    return <div>Hello</div>;
+}"#,
+        );
+        // Should only have mount frame wrapping for the component, not the nested function
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should wrap component: {}",
+            code
+        );
+    }
+
+    // ── Return expression is preserved ─────────────────────────────
+
+    #[test]
+    fn preserves_return_expression() {
+        let code = compile_tsx(
+            r#"function App() {
+    return <div>Hello</div>;
+}"#,
+        );
+        // The expression content should still be in the output
+        assert!(
+            code.contains("__mfResult"),
+            "should use result variable: {}",
+            code
+        );
+    }
+
+    // ── Braceless else return ──────────────────────────────────────
+
+    #[test]
+    fn handles_braceless_else_return() {
+        let code = compile_tsx(
+            r#"function App() {
+    if (true) return <span>A</span>;
+    else return <div>B</div>;
+}"#,
+        );
+        assert!(
+            code.matches("__flushMountFrame").count() >= 2,
+            "should handle both braceless returns: {}",
+            code
+        );
+    }
+
+    // ── Export function ────────────────────────────────────────────
+
+    #[test]
+    fn wraps_export_function() {
+        let code = compile_tsx(
+            r#"export function App() {
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should wrap exported function: {}",
+            code
+        );
+    }
+
+    // ── Export default function ─────────────────────────────────────
+
+    #[test]
+    fn wraps_export_default_function() {
+        let code = compile_tsx(
+            r#"export default function App() {
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(
+            code.contains("__pushMountFrame"),
+            "should wrap export default function: {}",
+            code
+        );
+    }
+}

--- a/native/vertz-compiler-core/src/props_transformer.rs
+++ b/native/vertz-compiler-core/src/props_transformer.rs
@@ -421,3 +421,198 @@ fn collect_block_var_names(body: &FunctionBody, names: &mut HashSet<String>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> String {
+        let result = compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        result.code
+    }
+
+    // ── Basic destructured props ───────────────────────────────────
+
+    #[test]
+    fn rewrites_destructured_prop_to_props_access() {
+        let code = compile_tsx(
+            r#"function Card({ title }) {
+    return <div>{title}</div>;
+}"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+        assert!(code.contains("__props"), "code: {}", code);
+    }
+
+    #[test]
+    fn rewrites_multiple_destructured_props() {
+        let code = compile_tsx(
+            r#"function Card({ title, subtitle }) {
+    return <div>{title}{subtitle}</div>;
+}"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+        assert!(code.contains("__props.subtitle"), "code: {}", code);
+    }
+
+    // ── Props with default values ──────────────────────────────────
+
+    #[test]
+    fn rewrites_prop_with_default_value() {
+        let code = compile_tsx(
+            r#"function Card({ title = 'default' }) {
+    return <div>{title}</div>;
+}"#,
+        );
+        assert!(
+            code.contains("__props.title ?? 'default'"),
+            "code: {}",
+            code
+        );
+    }
+
+    // ── Props with type annotation ─────────────────────────────────
+
+    #[test]
+    fn preserves_type_annotation_on_parameter() {
+        let code = compile_tsx(
+            r#"function Card({ title }: CardProps) {
+    return <div>{title}</div>;
+}"#,
+        );
+        // The type annotation should be moved to __props
+        assert!(code.contains("__props"), "code: {}", code);
+    }
+
+    // ── Rest element ───────────────────────────────────────────────
+
+    #[test]
+    fn generates_rest_destructuring_at_body_top() {
+        let code = compile_tsx(
+            r#"function Card({ title, ...rest }) {
+    return <div>{title}</div>;
+}"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+        assert!(code.contains("...rest"), "code: {}", code);
+    }
+
+    // ── No destructured props → no transform ───────────────────────
+
+    #[test]
+    fn no_transform_for_simple_props_param() {
+        let code = compile_tsx(
+            r#"function Card(props) {
+    return <div>{props.title}</div>;
+}"#,
+        );
+        // Should NOT have __props since it's not destructured
+        assert!(!code.contains("__props"), "code: {}", code);
+    }
+
+    #[test]
+    fn no_transform_for_no_params() {
+        let code = compile_tsx(
+            r#"function Card() {
+    return <div>Hello</div>;
+}"#,
+        );
+        assert!(!code.contains("__props"), "code: {}", code);
+    }
+
+    // ── Nested destructuring is skipped ────────────────────────────
+
+    #[test]
+    fn skips_nested_destructuring() {
+        let code = compile_tsx(
+            r#"function Card({ user: { name } }) {
+    return <div>{name}</div>;
+}"#,
+        );
+        // Should NOT rewrite because of nested destructuring
+        assert!(!code.contains("__props"), "code: {}", code);
+    }
+
+    // ── Shorthand object property ──────────────────────────────────
+
+    #[test]
+    fn rewrites_shorthand_object_property() {
+        let code = compile_tsx(
+            r#"function Card({ title }) {
+    const obj = { title };
+    return <div>{title}</div>;
+}"#,
+        );
+        // Shorthand { title } should become { title: __props.title }
+        assert!(code.contains("title: __props.title"), "code: {}", code);
+    }
+
+    // ── Arrow function component ───────────────────────────────────
+
+    #[test]
+    fn rewrites_arrow_function_component_props() {
+        let code = compile_tsx(
+            r#"const Card = ({ title }) => {
+    return <div>{title}</div>;
+};"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+    }
+
+    // ── Export function component ───────────────────────────────────
+
+    #[test]
+    fn rewrites_export_function_component_props() {
+        let code = compile_tsx(
+            r#"export function Card({ title }) {
+    return <div>{title}</div>;
+}"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+    }
+
+    // ── Export default function ─────────────────────────────────────
+
+    #[test]
+    fn rewrites_export_default_function_props() {
+        let code = compile_tsx(
+            r#"export default function Card({ title }) {
+    return <div>{title}</div>;
+}"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+    }
+
+    // ── Variable shadowing ─────────────────────────────────────────
+
+    #[test]
+    fn does_not_replace_shadowed_variable_in_arrow() {
+        let code = compile_tsx(
+            r#"function Card({ title }) {
+    const fn1 = (title) => title;
+    return <div>{title}</div>;
+}"#,
+        );
+        // The arrow param 'title' shadows the prop, so inner usage should not be __props.title
+        // But the return's {title} should be __props.title
+        assert!(code.contains("__props.title"), "code: {}", code);
+    }
+
+    // ── Export named variable ──────────────────────────────────────
+
+    #[test]
+    fn rewrites_export_const_arrow_component() {
+        let code = compile_tsx(
+            r#"export const Card = ({ title }) => {
+    return <div>{title}</div>;
+};"#,
+        );
+        assert!(code.contains("__props.title"), "code: {}", code);
+    }
+}

--- a/native/vertz-compiler-core/src/ssr_safety_diagnostics.rs
+++ b/native/vertz-compiler-core/src/ssr_safety_diagnostics.rs
@@ -314,3 +314,292 @@ impl<'a, 'b> Visit<'b> for SsrUnsafeDetector<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> Vec<crate::Diagnostic> {
+        let result = compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        result.diagnostics.unwrap_or_default()
+    }
+
+    fn ssr_diagnostics(diagnostics: &[crate::Diagnostic]) -> Vec<&crate::Diagnostic> {
+        diagnostics
+            .iter()
+            .filter(|d| d.message.contains("[ssr-unsafe-api]"))
+            .collect()
+    }
+
+    // ── Browser globals at top level → diagnostic ──────────────────
+
+    #[test]
+    fn reports_localstorage_at_top_level() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const x = localStorage.getItem('key');
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("localStorage"));
+    }
+
+    #[test]
+    fn reports_navigator_at_top_level() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const ua = navigator.userAgent;
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("navigator"));
+    }
+
+    #[test]
+    fn reports_intersection_observer() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const obs = IntersectionObserver;
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("IntersectionObserver"));
+    }
+
+    #[test]
+    fn reports_request_animation_frame() {
+        let diags = compile_tsx(
+            r#"function App() {
+    requestAnimationFrame(() => {});
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("requestAnimationFrame"));
+    }
+
+    // ── Browser global in nested function → no diagnostic ──────────
+
+    #[test]
+    fn no_report_in_arrow_function() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const handler = () => { localStorage.setItem('x', '1'); };
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    #[test]
+    fn no_report_in_function_expression() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const handler = function() { localStorage.setItem('x', '1'); };
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    // ── typeof guard → no diagnostic ───────────────────────────────
+
+    #[test]
+    fn no_report_with_typeof_guard_if() {
+        let diags = compile_tsx(
+            r#"function App() {
+    if (typeof localStorage !== 'undefined') {
+        localStorage.getItem('key');
+    }
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    #[test]
+    fn no_report_with_typeof_guard_ternary() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const x = typeof localStorage !== 'undefined' ? localStorage.getItem('key') : null;
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    #[test]
+    fn no_report_with_typeof_guard_logical_and() {
+        let diags = compile_tsx(
+            r#"function App() {
+    typeof localStorage !== 'undefined' && localStorage.getItem('key');
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    // ── typeof operand is safe ─────────────────────────────────────
+
+    #[test]
+    fn no_report_for_typeof_operand() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const hasStorage = typeof localStorage;
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    // ── window guard protects all globals ──────────────────────────
+
+    #[test]
+    fn window_guard_protects_all_globals() {
+        let diags = compile_tsx(
+            r#"function App() {
+    if (typeof window !== 'undefined') {
+        localStorage.getItem('key');
+        navigator.userAgent;
+    }
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    // ── document property access ───────────────────────────────────
+
+    #[test]
+    fn reports_document_query_selector() {
+        let diags = compile_tsx(
+            r#"function App() {
+    document.querySelector('.foo');
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("document.querySelector"));
+    }
+
+    #[test]
+    fn reports_document_get_element_by_id() {
+        let diags = compile_tsx(
+            r#"function App() {
+    document.getElementById('foo');
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("document.getElementById"));
+    }
+
+    #[test]
+    fn reports_document_cookie() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const c = document.cookie;
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].message.contains("document.cookie"));
+    }
+
+    // ── Multiple diagnostics ───────────────────────────────────────
+
+    #[test]
+    fn reports_multiple_browser_globals() {
+        let diags = compile_tsx(
+            r#"function App() {
+    const a = localStorage;
+    const b = sessionStorage;
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.len() >= 2);
+    }
+
+    // ── Diagnostic line/column ─────────────────────────────────────
+
+    #[test]
+    fn diagnostic_has_line_and_column() {
+        let diags = compile_tsx(
+            r#"function App() {
+    localStorage.getItem('key');
+    return <div>Hello</div>;
+}"#,
+        );
+        let ssr = ssr_diagnostics(&diags);
+        assert!(!ssr.is_empty());
+        assert!(ssr[0].line.is_some());
+        assert!(ssr[0].column.is_some());
+    }
+
+    // ── No component → no diagnostics ──────────────────────────────
+
+    #[test]
+    fn no_diagnostic_when_no_component() {
+        let diags = compile_tsx("const x = localStorage.getItem('key');");
+        let ssr = ssr_diagnostics(&diags);
+        assert!(ssr.is_empty());
+    }
+
+    // ── All browser globals are detected ───────────────────────────
+
+    #[test]
+    fn detects_all_browser_globals() {
+        for global in super::BROWSER_GLOBALS {
+            let source = format!(
+                "function App() {{\n    const x = {};\n    return <div>Hello</div>;\n}}",
+                global
+            );
+            let diags = compile_tsx(&source);
+            let ssr = ssr_diagnostics(&diags);
+            assert!(!ssr.is_empty(), "expected diagnostic for '{}'", global);
+        }
+    }
+
+    // ── All document properties are detected ───────────────────────
+
+    #[test]
+    fn detects_all_document_properties() {
+        for prop in super::DOCUMENT_PROPERTIES {
+            let source = format!(
+                "function App() {{\n    document.{};\n    return <div>Hello</div>;\n}}",
+                prop
+            );
+            let diags = compile_tsx(&source);
+            let ssr = ssr_diagnostics(&diags);
+            assert!(
+                !ssr.is_empty(),
+                "expected diagnostic for 'document.{}'",
+                prop
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 120 tests across 6 files in `vertz-compiler-core` to increase coverage toward 95%+
- **lib.rs** (35 tests): full compile pipeline, parser errors, all options (fast_refresh, field_selection, hydration_markers, prefetch_manifest, target), compile_for_ssr_aot, manifest registry, TypeScript stripping, CSS extraction
- **mount_frame_transformer.rs** (12 tests): mount frame wrapping with try/catch, multiple/braceless/bare returns, arrow expression and block bodies
- **ssr_safety_diagnostics.rs** (19 tests): browser globals detection, typeof guards (if/ternary/logical AND), window universal guard, document properties, nested function exclusion
- **body_jsx_diagnostics.rs** (7 tests): JSX outside return tree, nested functions, fragments
- **props_transformer.rs** (14 tests): destructured props rewriting, defaults, rest elements, type annotations, shadowing, shorthand objects
- **import_injection.rs** (33 tests): runtime/DOM helper detection, TUI target, existing binding skip, comment stripping

Closes #11

## Test plan

- [x] All 120 new tests pass
- [x] Full quality gates green (`cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check`)
- [x] No existing tests broken (425 total in vertz-compiler-core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)