### PR TITLE
test(compiler): add coverage for mutation/query transforms

### DIFF
--- a/native/vertz-compiler-core/src/mutation_analyzer.rs
+++ b/native/vertz-compiler-core/src/mutation_analyzer.rs
@@ -210,3 +210,298 @@ fn get_root_identifier(expr: &Expression) -> Option<String> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> crate::CompileResult {
+        compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        )
+    }
+
+    // Mutation analyzer is tested via compile() since it requires AST.
+    // When mutations are detected on `let` variables (classified as Signal),
+    // the mutation_transformer wraps them with peek()/notify().
+
+    // ── MethodCall mutations ─────────────────────────────────────
+
+    #[test]
+    fn detects_push_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [];
+    items.push(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_pop_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2];
+    items.pop();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_shift_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1];
+    items.shift();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_unshift_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [];
+    items.unshift(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_splice_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2, 3];
+    items.splice(0, 1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_sort_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [3, 1, 2];
+    items.sort();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_reverse_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2];
+    items.reverse();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_fill_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2, 3];
+    items.fill(0);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn detects_copy_within_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2, 3];
+    items.copyWithin(0, 1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    // ── PropertyAssignment ───────────────────────────────────────
+
+    #[test]
+    fn detects_property_assignment() {
+        let result = compile_tsx(
+            r#"function App() {
+    let obj = { name: '' };
+    obj.name = 'test';
+    return <div>{obj.name}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    // ── IndexAssignment ──────────────────────────────────────────
+
+    #[test]
+    fn detects_index_assignment() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2, 3];
+    items[0] = 99;
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    // ── Delete ───────────────────────────────────────────────────
+
+    #[test]
+    fn detects_delete_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let obj = { key: 'val' };
+    delete obj.key;
+    return <div>{obj.key}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    // ── ObjectAssign ─────────────────────────────────────────────
+
+    #[test]
+    fn detects_object_assign_mutation() {
+        let result = compile_tsx(
+            r#"function App() {
+    let obj = { a: 1 };
+    Object.assign(obj, { b: 2 });
+    return <div>{obj.a}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    // ── No mutation on non-signal (const) variables ──────────────
+
+    #[test]
+    fn no_mutation_detected_for_const_variables() {
+        // const variables are not classified as Signal, so no peek/notify
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        // const items is Static, not Signal — mutation_analyzer skips it
+        // (mutation_diagnostics will warn instead)
+        assert!(!result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    // ── No mutation for non-JSX-reachable let variables ──────────
+
+    #[test]
+    fn no_mutation_for_let_not_in_jsx() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [];
+    items.push(1);
+    return <div>hello</div>;
+}"#,
+        );
+        // items is let but not in JSX, so classified as Static
+        assert!(!result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    // ── Multiple mutations in same component ─────────────────────
+
+    #[test]
+    fn multiple_mutations_detected() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [];
+    items.push(1);
+    items.pop();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        // Both mutations should be transformed
+        let peek_count = result.code.matches(".peek()").count();
+        assert!(
+            peek_count >= 2,
+            "expected 2+ peek() calls, got {}: {}",
+            peek_count,
+            result.code
+        );
+    }
+
+    // ── Non-mutation methods not detected ─────────────────────────
+
+    #[test]
+    fn non_mutation_methods_not_transformed() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [1, 2, 3];
+    const mapped = items.map(x => x * 2);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        // .map() is not a mutation method — should not get peek/notify
+        // (items.length in JSX will get .value transform instead)
+        assert!(
+            !result.code.contains("items.peek().map"),
+            "code: {}",
+            result.code
+        );
+    }
+
+    // ── Chained member expression detects root ───────────────────
+
+    #[test]
+    fn chained_member_expression_detects_root_signal() {
+        let result = compile_tsx(
+            r#"function App() {
+    let data = { nested: [] };
+    data.nested.push(1);
+    return <div>{data.nested.length}</div>;
+}"#,
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+    }
+
+    // ── Mutations on different variables ─────────────────────────
+
+    #[test]
+    fn mutations_on_different_signal_variables() {
+        let result = compile_tsx(
+            r#"function App() {
+    let a = [];
+    let b = { x: 1 };
+    a.push(1);
+    b.x = 2;
+    return <div>{a.length}{b.x}</div>;
+}"#,
+        );
+        assert!(result.code.contains("a.peek()"), "code: {}", result.code);
+        assert!(result.code.contains("b.peek()"), "code: {}", result.code);
+    }
+}

--- a/native/vertz-compiler-core/src/mutation_diagnostics.rs
+++ b/native/vertz-compiler-core/src/mutation_diagnostics.rs
@@ -200,3 +200,397 @@ fn get_root_identifier<'a>(expr: &'a Expression) -> Option<&'a str> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> crate::CompileResult {
+        compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn has_mutation_diag(result: &crate::CompileResult) -> bool {
+        result
+            .diagnostics
+            .as_ref()
+            .map(|ds| {
+                ds.iter()
+                    .any(|d| d.message.contains("non-reactive-mutation"))
+            })
+            .unwrap_or(false)
+    }
+
+    fn mutation_diags(result: &crate::CompileResult) -> Vec<&crate::Diagnostic> {
+        result
+            .diagnostics
+            .as_ref()
+            .map(|ds| {
+                ds.iter()
+                    .filter(|d| d.message.contains("non-reactive-mutation"))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    // ── Method call mutations on const → diagnostic ──────────────
+
+    #[test]
+    fn push_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(
+            has_mutation_diag(&result),
+            "diags: {:?}",
+            result.diagnostics
+        );
+        let diags = mutation_diags(&result);
+        assert!(diags[0].message.contains(".push()"));
+        assert!(diags[0].message.contains("const items"));
+    }
+
+    #[test]
+    fn pop_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1, 2];
+    items.pop();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".pop()"));
+    }
+
+    #[test]
+    fn shift_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1];
+    items.shift();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".shift()"));
+    }
+
+    #[test]
+    fn unshift_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.unshift(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".unshift()"));
+    }
+
+    #[test]
+    fn splice_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1, 2, 3];
+    items.splice(0, 1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".splice()"));
+    }
+
+    #[test]
+    fn sort_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [3, 1, 2];
+    items.sort();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".sort()"));
+    }
+
+    #[test]
+    fn reverse_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1, 2];
+    items.reverse();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".reverse()"));
+    }
+
+    #[test]
+    fn fill_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1, 2, 3];
+    items.fill(0);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".fill()"));
+    }
+
+    #[test]
+    fn copy_within_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1, 2, 3];
+    items.copyWithin(0, 1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+        assert!(mutation_diags(&result)[0].message.contains(".copyWithin()"));
+    }
+
+    // ── Property assignment mutation on const → diagnostic ───────
+
+    #[test]
+    fn property_assignment_on_const_in_jsx_produces_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const obj = { name: '' };
+    obj.name = 'test';
+    return <div>{obj.name}</div>;
+}"#,
+        );
+        assert!(
+            has_mutation_diag(&result),
+            "diags: {:?}",
+            result.diagnostics
+        );
+        let diags = mutation_diags(&result);
+        assert!(diags[0].message.contains("Property assignment"));
+        assert!(diags[0].message.contains("const obj"));
+    }
+
+    // ── No diagnostic when const not in JSX ──────────────────────
+
+    #[test]
+    fn no_diagnostic_when_const_not_in_jsx() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>hello</div>;
+}"#,
+        );
+        assert!(
+            !has_mutation_diag(&result),
+            "diags: {:?}",
+            result.diagnostics
+        );
+    }
+
+    // ── No diagnostic for let variables ──────────────────────────
+
+    #[test]
+    fn no_diagnostic_for_let_variables() {
+        let result = compile_tsx(
+            r#"function App() {
+    let items = [];
+    items.push(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(
+            !has_mutation_diag(&result),
+            "diags: {:?}",
+            result.diagnostics
+        );
+    }
+
+    // ── Non-mutating methods produce no diagnostic ───────────────
+
+    #[test]
+    fn non_mutation_methods_no_diagnostic() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [1, 2, 3];
+    const mapped = items.map(x => x * 2);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        assert!(
+            !has_mutation_diag(&result),
+            "diags: {:?}",
+            result.diagnostics
+        );
+    }
+
+    // ── Line and column in diagnostics ───────────────────────────
+
+    #[test]
+    fn diagnostic_includes_line_and_column() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        let diags = mutation_diags(&result);
+        assert!(!diags.is_empty());
+        assert!(diags[0].line.is_some());
+        assert!(diags[0].column.is_some());
+    }
+
+    // ── Multiple diagnostics ─────────────────────────────────────
+
+    #[test]
+    fn multiple_mutations_produce_multiple_diagnostics() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    items.pop();
+    return <div>{items.length}</div>;
+}"#,
+        );
+        let diags = mutation_diags(&result);
+        assert!(diags.len() >= 2, "expected 2+ diags, got: {:?}", diags);
+    }
+
+    #[test]
+    fn diagnostics_on_different_const_vars() {
+        let result = compile_tsx(
+            r#"function App() {
+    const a = [];
+    const b = [];
+    a.push(1);
+    b.push(2);
+    return <div>{a.length}{b.length}</div>;
+}"#,
+        );
+        let diags = mutation_diags(&result);
+        assert!(diags.len() >= 2, "expected 2+ diags, got: {:?}", diags);
+    }
+
+    // ── Diagnostic message suggests changing to let ──────────────
+
+    #[test]
+    fn diagnostic_suggests_let() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.length}</div>;
+}"#,
+        );
+        let diags = mutation_diags(&result);
+        assert!(diags[0].message.contains("Change `const` to `let`"));
+    }
+
+    // ── JSX reference collection patterns ────────────────────────
+
+    #[test]
+    fn jsx_member_expression_reference() {
+        let result = compile_tsx(
+            r#"function App() {
+    const obj = { name: 'x' };
+    obj.name = 'y';
+    return <div>{obj.name}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+    }
+
+    #[test]
+    fn jsx_conditional_expression_reference() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.length > 0 ? 'yes' : 'no'}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+    }
+
+    #[test]
+    fn jsx_binary_expression_reference() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.length + 1}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+    }
+
+    #[test]
+    fn jsx_template_literal_reference() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{`count: ${items.length}`}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+    }
+
+    #[test]
+    fn jsx_call_expression_reference() {
+        let result = compile_tsx(
+            r#"function App() {
+    const items = [];
+    items.push(1);
+    return <div>{items.join(',')}</div>;
+}"#,
+        );
+        // items is referenced via call expression callee in JSX
+        assert!(has_mutation_diag(&result));
+    }
+
+    // ── Chained member expression ────────────────────────────────
+
+    #[test]
+    fn chained_member_expression_detects_root() {
+        let result = compile_tsx(
+            r#"function App() {
+    const obj = { nested: [] };
+    obj.nested.push(1);
+    return <div>{obj.nested.length}</div>;
+}"#,
+        );
+        assert!(has_mutation_diag(&result));
+    }
+
+    // ── Property assignment with both push and assign ────────────
+
+    #[test]
+    fn mixed_mutation_types_produce_diagnostics() {
+        let result = compile_tsx(
+            r#"function App() {
+    const obj = { items: [], name: '' };
+    obj.items.push(1);
+    obj.name = 'test';
+    return <div>{obj.name}</div>;
+}"#,
+        );
+        let diags = mutation_diags(&result);
+        assert!(diags.len() >= 2, "expected 2+ diags, got: {:?}", diags);
+    }
+}

--- a/native/vertz-compiler-core/src/mutation_transformer.rs
+++ b/native/vertz-compiler-core/src/mutation_transformer.rs
@@ -65,3 +65,246 @@ fn replace_with_boundary(text: &str, var_name: &str, suffix: &str, replacement: 
     result.push_str(remaining);
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::magic_string::MagicString;
+    use crate::mutation_analyzer::MutationInfo;
+
+    fn transform(source: &str, mutations: &[MutationInfo]) -> String {
+        let mut ms = MagicString::new(source);
+        transform_mutations(&mut ms, mutations);
+        ms.to_string()
+    }
+
+    // ── Empty mutations ────────────────────────────────────────────
+
+    #[test]
+    fn no_changes_when_no_mutations() {
+        let result = transform("items.push(1);", &[]);
+        assert_eq!(result, "items.push(1);");
+    }
+
+    // ── MethodCall kind ────────────────────────────────────────────
+
+    #[test]
+    fn method_call_wraps_with_peek_and_notify() {
+        let source = "items.push(1)";
+        let result = transform(
+            source,
+            &[MutationInfo {
+                variable_name: "items".to_string(),
+                kind: MutationKind::MethodCall,
+                start: 0,
+                end: source.len() as u32,
+            }],
+        );
+        assert!(
+            result.contains("items.peek().push(1)"),
+            "result: {}",
+            result
+        );
+        assert!(result.contains("items.notify()"), "result: {}", result);
+    }
+
+    // ── PropertyAssignment kind ────────────────────────────────────
+
+    #[test]
+    fn property_assignment_wraps_with_peek_and_notify() {
+        let source = "obj.name = 'x'";
+        let result = transform(
+            source,
+            &[MutationInfo {
+                variable_name: "obj".to_string(),
+                kind: MutationKind::PropertyAssignment,
+                start: 0,
+                end: source.len() as u32,
+            }],
+        );
+        assert!(result.contains("obj.peek().name"), "result: {}", result);
+        assert!(result.contains("obj.notify()"), "result: {}", result);
+    }
+
+    // ── IndexAssignment kind ───────────────────────────────────────
+
+    #[test]
+    fn index_assignment_wraps_with_peek_and_notify() {
+        let source = "items[0] = 'x'";
+        let result = transform(
+            source,
+            &[MutationInfo {
+                variable_name: "items".to_string(),
+                kind: MutationKind::IndexAssignment,
+                start: 0,
+                end: source.len() as u32,
+            }],
+        );
+        assert!(result.contains("items.peek()[0]"), "result: {}", result);
+        assert!(result.contains("items.notify()"), "result: {}", result);
+    }
+
+    // ── Delete kind ────────────────────────────────────────────────
+
+    #[test]
+    fn delete_wraps_with_peek_and_notify() {
+        let source = "delete obj.key";
+        let result = transform(
+            source,
+            &[MutationInfo {
+                variable_name: "obj".to_string(),
+                kind: MutationKind::Delete,
+                start: 0,
+                end: source.len() as u32,
+            }],
+        );
+        assert!(result.contains("obj.peek().key"), "result: {}", result);
+        assert!(result.contains("obj.notify()"), "result: {}", result);
+    }
+
+    // ── ObjectAssign kind ──────────────────────────────────────────
+
+    #[test]
+    fn object_assign_wraps_with_peek_and_notify() {
+        let source = "Object.assign(obj, { a: 1 })";
+        let result = transform(
+            source,
+            &[MutationInfo {
+                variable_name: "obj".to_string(),
+                kind: MutationKind::ObjectAssign,
+                start: 0,
+                end: source.len() as u32,
+            }],
+        );
+        assert!(
+            result.contains("Object.assign(obj.peek()"),
+            "result: {}",
+            result
+        );
+        assert!(result.contains("obj.notify()"), "result: {}", result);
+    }
+
+    // ── Multiple mutations processed in reverse order ──────────────
+
+    #[test]
+    fn multiple_mutations_processed_correctly() {
+        let source = "a.push(1); b.pop()";
+        let result = transform(
+            source,
+            &[
+                MutationInfo {
+                    variable_name: "a".to_string(),
+                    kind: MutationKind::MethodCall,
+                    start: 0,
+                    end: 9,
+                },
+                MutationInfo {
+                    variable_name: "b".to_string(),
+                    kind: MutationKind::MethodCall,
+                    start: 11,
+                    end: 18,
+                },
+            ],
+        );
+        assert!(result.contains("a.peek().push(1)"), "result: {}", result);
+        assert!(result.contains("b.peek().pop()"), "result: {}", result);
+    }
+
+    // ── replace_with_boundary respects word boundaries ─────────────
+
+    #[test]
+    fn replace_with_boundary_skips_non_boundary() {
+        // "xitems.push" should not match "items" because 'x' precedes it
+        let result = replace_with_boundary("xitems.push(1)", "items", ".", "items.peek().");
+        assert_eq!(result, "xitems.push(1)");
+    }
+
+    #[test]
+    fn replace_with_boundary_matches_at_start() {
+        let result = replace_with_boundary("items.push(1)", "items", ".", "items.peek().");
+        assert_eq!(result, "items.peek().push(1)");
+    }
+
+    #[test]
+    fn replace_with_boundary_skips_underscore_prefix() {
+        let result = replace_with_boundary("_items.push(1)", "items", ".", "items.peek().");
+        assert_eq!(result, "_items.push(1)");
+    }
+
+    #[test]
+    fn replace_with_boundary_skips_dollar_prefix() {
+        let result = replace_with_boundary("$items.push(1)", "items", ".", "items.peek().");
+        assert_eq!(result, "$items.push(1)");
+    }
+
+    #[test]
+    fn replace_with_boundary_skips_digit_prefix() {
+        let result = replace_with_boundary("1items.push(1)", "items", ".", "items.peek().");
+        assert_eq!(result, "1items.push(1)");
+    }
+
+    #[test]
+    fn replace_with_boundary_matches_after_space() {
+        let result = replace_with_boundary(" items.push(1)", "items", ".", "items.peek().");
+        assert_eq!(result, " items.peek().push(1)");
+    }
+
+    #[test]
+    fn replace_with_boundary_matches_after_paren() {
+        let result = replace_with_boundary("(items.push(1))", "items", ".", "items.peek().");
+        assert_eq!(result, "(items.peek().push(1))");
+    }
+
+    // ── End-to-end through compile ─────────────────────────────────
+
+    #[test]
+    fn compile_transforms_array_push_mutation() {
+        let result = crate::compile(
+            r#"function App() {
+    let items = [];
+    items.push('new');
+    return <div>{items.length}</div>;
+}"#,
+            crate::CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn compile_transforms_property_assignment_mutation() {
+        let result = crate::compile(
+            r#"function App() {
+    let obj = { name: '' };
+    obj.name = 'test';
+    return <div>{obj.name}</div>;
+}"#,
+            crate::CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+
+    #[test]
+    fn compile_transforms_delete_mutation() {
+        let result = crate::compile(
+            r#"function App() {
+    let obj = { key: 'val' };
+    delete obj.key;
+    return <div>{obj.key}</div>;
+}"#,
+            crate::CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(result.code.contains(".peek()"), "code: {}", result.code);
+        assert!(result.code.contains(".notify()"), "code: {}", result.code);
+    }
+}

--- a/native/vertz-compiler-core/src/query_auto_thunk.rs
+++ b/native/vertz-compiler-core/src/query_auto_thunk.rs
@@ -206,3 +206,285 @@ impl<'a, 'c> Visit<'c> for ReactiveRefChecker<'a> {
         self.shadowed_stack.pop();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{compile, CompileOptions};
+
+    fn compile_tsx(source: &str) -> crate::CompileResult {
+        compile(
+            source,
+            CompileOptions {
+                filename: Some("test.tsx".to_string()),
+                ..Default::default()
+            },
+        )
+    }
+
+    // ── Basic thunk wrapping ─────────────────────────────────────
+
+    #[test]
+    fn wraps_query_arg_with_thunk_when_reactive_var_present() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(fetch('/api', { offset }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        assert!(
+            result.code.contains("() => "),
+            "expected thunk wrapper, code: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn no_thunk_when_no_reactive_vars() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    const q = query(fetch('/api'));
+    return <div>hello</div>;
+}"#,
+        );
+        // No reactive vars → no thunk wrapping
+        assert!(
+            !result.code.contains("() => fetch"),
+            "should not wrap, code: {}",
+            result.code
+        );
+    }
+
+    // ── Skip already-wrapped functions ───────────────────────────
+
+    #[test]
+    fn skip_arrow_function_argument() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(() => fetch('/api', { offset }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        // Already an arrow function — should NOT double-wrap
+        assert!(
+            !result.code.contains("() => () =>"),
+            "should not double-wrap, code: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn skip_function_expression_argument() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(function() { return fetch('/api', { offset }); });
+    return <div>{offset}</div>;
+}"#,
+        );
+        assert!(
+            !result.code.contains("() => function"),
+            "should not wrap function expression, code: {}",
+            result.code
+        );
+    }
+
+    // ── Skip spread arguments ────────────────────────────────────
+
+    #[test]
+    fn skip_spread_argument() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let args = [];
+    const q = query(...args);
+    return <div>{args.length}</div>;
+}"#,
+        );
+        // Spread arguments should not be wrapped
+        assert!(
+            !result.code.contains("() => ..."),
+            "should not wrap spread, code: {}",
+            result.code
+        );
+    }
+
+    // ── Shorthand object properties ──────────────────────────────
+
+    #[test]
+    fn detects_reactive_var_in_shorthand_object_property() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(apiCall({ offset }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        assert!(
+            result.code.contains("() => "),
+            "shorthand prop should trigger thunk, code: {}",
+            result.code
+        );
+    }
+
+    // ── Aliased query import ─────────────────────────────────────
+
+    #[test]
+    fn works_with_aliased_query_import() {
+        let result = compile_tsx(
+            r#"import { query as myQuery } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = myQuery(fetch('/api', { offset }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        assert!(
+            result.code.contains("() => "),
+            "aliased query should still wrap, code: {}",
+            result.code
+        );
+    }
+
+    // ── Non-query callee not affected ────────────────────────────
+
+    #[test]
+    fn non_query_callee_not_wrapped() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const result = someOtherFn(fetch('/api', { offset }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        // someOtherFn is not query — should not wrap
+        assert!(
+            !result.code.contains("() => fetch"),
+            "non-query should not wrap, code: {}",
+            result.code
+        );
+    }
+
+    // ── Member expression property skipping ──────────────────────
+
+    #[test]
+    fn skips_property_names_in_member_expressions() {
+        // If reactive var name appears as a property (not object), should not trigger
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(api.offset);
+    return <div>{offset}</div>;
+}"#,
+        );
+        // `offset` in `api.offset` is a property name, not a variable reference
+        assert!(
+            !result.code.contains("() => api"),
+            "property name should not trigger thunk, code: {}",
+            result.code
+        );
+    }
+
+    // ── Shadowed variables ───────────────────────────────────────
+
+    #[test]
+    fn shadowed_var_in_arrow_does_not_trigger_thunk() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(((offset) => doSomething(offset))(5));
+    return <div>{offset}</div>;
+}"#,
+        );
+        // offset is shadowed by the arrow param, so no reactive ref
+        assert!(
+            !result.code.contains("() => ((offset)"),
+            "shadowed var should not trigger thunk, code: {}",
+            result.code
+        );
+    }
+
+    // ── No query import → no transform ───────────────────────────
+
+    #[test]
+    fn no_query_import_no_transform() {
+        let result = compile_tsx(
+            r#"function App() {
+    let offset = 0;
+    const q = query(fetch('/api', { offset }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        // query is not imported from @vertz/ui — should not wrap
+        assert!(
+            !result.code.contains("() => fetch"),
+            "no import should not wrap, code: {}",
+            result.code
+        );
+    }
+
+    // ── Computed member expression visits both parts ──────────────
+
+    #[test]
+    fn computed_member_expression_detects_reactive_in_expression() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let idx = 0;
+    const q = query(items[idx]);
+    return <div>{idx}</div>;
+}"#,
+        );
+        assert!(
+            result.code.contains("() => "),
+            "computed member expr should detect reactive, code: {}",
+            result.code
+        );
+    }
+
+    // ── No arguments → no crash ──────────────────────────────────
+
+    #[test]
+    fn query_with_no_args_does_not_crash() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let x = 0;
+    const q = query();
+    return <div>{x}</div>;
+}"#,
+        );
+        // Should not panic
+        assert!(!result.code.is_empty());
+    }
+
+    // ── Object property key not treated as reference ─────────────
+
+    #[test]
+    fn object_key_not_treated_as_reactive_ref() {
+        let result = compile_tsx(
+            r#"import { query } from '@vertz/ui';
+function App() {
+    let offset = 0;
+    const q = query(doStuff({ offset: 42 }));
+    return <div>{offset}</div>;
+}"#,
+        );
+        // `offset` in `{ offset: 42 }` is a key, not a reactive reference
+        // The value is 42 (literal), not a reactive var
+        assert!(
+            !result.code.contains("() => doStuff"),
+            "object key should not trigger thunk, code: {}",
+            result.code
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds 74 tests across 4 mutation/query-related modules in `vertz-compiler-core` to bring coverage from 10-51% to 95%+
- **mutation_transformer.rs** (10% → 95%+): 17 tests covering all 5 MutationKind variants (MethodCall, PropertyAssignment, IndexAssignment, Delete, ObjectAssign), word boundary replacement, multiple mutations, and 3 end-to-end compile tests
- **mutation_analyzer.rs** (45.9% → 95%+): 19 tests covering all 9 mutation methods, property/index assignment, delete, Object.assign, chained member expressions, and negative cases
- **mutation_diagnostics.rs** (51.1% → 95%+): 24 tests covering all 9 mutation method diagnostics, property assignment diagnostics, JSX reference collection patterns (member, conditional, binary, template literal, call), line/column info, and negative cases
- **query_auto_thunk.rs** (14.5% → 95%+): 14 tests covering thunk wrapping with reactive vars, skip already-wrapped functions, spread arguments, shorthand properties, shadowed variables, member expression skipping, aliased imports

Closes #9

## Test plan

- [x] All 74 new tests pass
- [x] Full test suite passes (2555 tests)
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)