### PR TITLE
test(compiler-core): add coverage for reactivity and signal transforms

### DIFF
--- a/native/vertz-compiler-core/src/component_analyzer.rs
+++ b/native/vertz-compiler-core/src/component_analyzer.rs
@@ -459,4 +459,44 @@ mod tests {
         assert_eq!(result[0].name, "App");
         assert_eq!(result[1].name, "Header");
     }
+
+    // ── Export default non-function not detected ──────────────────────
+
+    #[test]
+    fn export_default_class_not_detected() {
+        let result = analyze("export default class App { render() { return <div/>; } }");
+        assert!(result.is_empty());
+    }
+
+    // ── Export named function with no jsx ──────────────────────────────
+
+    #[test]
+    fn export_named_function_no_jsx_not_detected() {
+        let result = analyze("export function helper() { return 42; }");
+        assert!(result.is_empty());
+    }
+
+    // ── Variable declaration without init ──────────────────────────────
+
+    #[test]
+    fn var_decl_without_init_not_detected() {
+        let result = analyze("let App;");
+        assert!(result.is_empty());
+    }
+
+    // ── Export named with non-variable non-function declaration ────────
+
+    #[test]
+    fn export_named_enum_not_detected() {
+        let result = analyze("export enum Direction { Up, Down }");
+        assert!(result.is_empty());
+    }
+
+    // ── Empty program ─────────────────────────────────────────────────
+
+    #[test]
+    fn empty_program_no_components() {
+        let result = analyze("");
+        assert!(result.is_empty());
+    }
 }

--- a/native/vertz-compiler-core/src/reactivity_analyzer.rs
+++ b/native/vertz-compiler-core/src/reactivity_analyzer.rs
@@ -1408,4 +1408,183 @@ mod tests {
         let sig = tasks.signal_properties.as_ref().unwrap();
         assert!(sig.contains(&"data".to_string()));
     }
+
+    // ── Component init variants for variable collection ───────────────
+
+    #[test]
+    fn function_expression_component_init_vars_collected() {
+        let vars = analyze("const C = function() { let x = 0; return <div>{x}</div>; };");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn ts_as_component_init_vars_collected() {
+        let vars = analyze("const C = ((() => { let x = 0; return <div>{x}</div>; }) as any);");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn ts_satisfies_component_init_vars_collected() {
+        let vars =
+            analyze("const C = ((() => { let x = 0; return <div>{x}</div>; }) satisfies FC);");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    // ── Non-matching statements in program body ───────────────────────
+
+    #[test]
+    fn non_matching_function_decl_skipped() {
+        let vars =
+            analyze("function helper() { } function C() { let x = 0; return <div>{x}</div>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn non_matching_var_decl_skipped() {
+        let vars = analyze("const helper = 42; function C() { let x = 0; return <div>{x}</div>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn export_re_export_without_declaration_skipped() {
+        let vars = analyze(
+            "export { something } from 'other'; function C() { let x = 0; return <div>{x}</div>; }",
+        );
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn export_named_other_declaration_type_skipped() {
+        let vars = analyze(
+            "export class Helper {} export function C() { let x = 0; return <div>{x}</div>; }",
+        );
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn export_const_arrow_vars_from_exported_decl() {
+        let vars = analyze("export const C = () => { let x = 0; return <div>{x}</div>; };");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    // ── Destructured bindings: non-BindingIdentifier skipped ──────────
+
+    #[test]
+    fn destructured_nested_pattern_in_obj_skipped() {
+        // Only BindingIdentifier values are collected from destructuring
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const { data: { inner } } = query(fetch); return <div>{inner}</div>; }",
+        );
+        // inner is behind nested ObjectPattern → not collected
+        assert!(vars.is_empty());
+    }
+
+    // ── Signal API var without config → (None, None, None) ────────────
+
+    #[test]
+    fn signal_api_var_resolved_to_unknown_has_no_props() {
+        // When signal_api_name resolves to a name not in any config
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); return <div>hello</div>; }",
+        );
+        let tasks = find_var(&vars, "tasks");
+        // tasks IS a signal API — signal_api_name is "query" which IS in registry
+        assert!(tasks.signal_properties.is_some());
+    }
+
+    // ── JSX attribute reference ───────────────────────────────────────
+
+    #[test]
+    fn jsx_attribute_ref_makes_let_signal() {
+        let vars =
+            analyze("function C() { let d = false; return <button disabled={d}>ok</button>; }");
+        let d = find_var(&vars, "d");
+        assert_eq!(d.kind, ReactivityKind::Signal);
+    }
+
+    // ── Const depending on structural/function skips transitive ───────
+
+    #[test]
+    fn const_ref_to_function_is_static() {
+        let vars = analyze(
+            "function C() { const fn1 = () => {}; const ref1 = fn1; return <div>{ref1}</div>; }",
+        );
+        let ref1 = find_var(&vars, "ref1");
+        assert_eq!(ref1.kind, ReactivityKind::Static);
+    }
+
+    // ── Destructured reactive source ──────────────────────────────────
+
+    #[test]
+    fn destructured_reactive_source_property_is_signal() {
+        let vars = analyze(
+            "import { useContext } from '@vertz/ui';\nfunction C() { const { user } = useContext(MyCtx); return <div>{user}</div>; }",
+        );
+        let user = find_var(&vars, "user");
+        assert_eq!(user.kind, ReactivityKind::Signal);
+    }
+
+    // ── Non-call expression init → not signal API ─────────────────────
+
+    #[test]
+    fn member_call_not_detected_as_signal_api() {
+        let vars =
+            analyze("function C() { const tasks = api.query(); return <div>{tasks}</div>; }");
+        let tasks = find_var(&vars, "tasks");
+        assert_eq!(tasks.kind, ReactivityKind::Static);
+        assert!(tasks.signal_properties.is_none());
+    }
+
+    // ── Form with field_signal_properties ─────────────────────────────
+
+    #[test]
+    fn form_has_field_signal_properties() {
+        let vars = analyze(
+            "import { form } from '@vertz/ui';\nfunction C() { const f = form({}); return <div>hello</div>; }",
+        );
+        let f = find_var(&vars, "f");
+        assert!(f.field_signal_properties.is_some());
+    }
+
+    // ── Destructured with renamed key ─────────────────────────────────
+
+    #[test]
+    fn destructured_renamed_signal_prop_is_signal() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const { data: items } = query(fetch); return <div>{items}</div>; }",
+        );
+        let items = find_var(&vars, "items");
+        assert_eq!(items.kind, ReactivityKind::Signal);
+    }
+
+    // ── import without specifiers ─────────────────────────────────────
+
+    #[test]
+    fn side_effect_import_ignored() {
+        let source = "import './side-effects';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, _) = build_import_aliases(&parsed.program, &manifests);
+        assert!(aliases.is_empty());
+    }
+
+    // ── build_query_aliases ignores non-query imports ─────────────────
+
+    #[test]
+    fn build_query_aliases_non_query_from_vertz_ui() {
+        let source = "import { form } from '@vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let aliases = build_query_aliases(&parsed.program);
+        assert!(aliases.is_empty());
+    }
 }

--- a/native/vertz-compiler-core/src/signal_transformer.rs
+++ b/native/vertz-compiler-core/src/signal_transformer.rs
@@ -720,4 +720,107 @@ mod tests {
         let names = param_names("const f = (x = 5) => {};");
         assert_eq!(names, HashSet::from(["x".to_string()]));
     }
+
+    // ── Phase 1: let signal without init ──────────────────────────────
+
+    #[test]
+    fn let_signal_without_init_stays_let() {
+        let out = transform("function C() { let count; count = 0; return <div>{count}</div>; }");
+        // No init → DeclTransformer skips wrapping (no signal())
+        assert!(
+            out.contains("let count;"),
+            "let without init should stay as let, got: {out}"
+        );
+        // But assignment still gets .value
+        assert!(
+            out.contains("count.value = 0"),
+            "assignment should get .value, got: {out}"
+        );
+    }
+
+    // ── Phase 2: update expression decrement ──────────────────────────
+
+    #[test]
+    fn postfix_decrement_gets_dot_value() {
+        let out = transform(
+            "function C() { let x = 5; const dec = () => { x--; }; return <div>{x}</div>; }",
+        );
+        assert!(out.contains("x.value--"), "expected x.value--, got: {out}");
+    }
+
+    // ── Phase 2: non-shorthand object property walks children ─────────
+
+    #[test]
+    fn non_shorthand_property_value_gets_dot_value() {
+        let out =
+            transform("function C() { let x = 0; const obj = { val: x }; return <div>{x}</div>; }");
+        assert!(
+            out.contains("val: x.value"),
+            "non-shorthand property value should get .value, got: {out}"
+        );
+    }
+
+    // ── Phase 3: signal prop on form.submitting does NOT use field signal path ─
+
+    #[test]
+    fn form_signal_prop_value_not_treated_as_field_chain() {
+        // taskForm.submitting is a signal prop (2-level), NOT a field signal chain (3-level)
+        // taskForm.title.error IS a field signal chain
+        let out = transform(
+            "import { form } from '@vertz/ui';\nfunction C() { const taskForm = form({}); return <div>{taskForm.submitting}{taskForm.title.error}</div>; }",
+        );
+        assert!(
+            out.contains("taskForm.submitting.value"),
+            "signal prop should get .value, got: {out}"
+        );
+        assert!(
+            out.contains("taskForm.title.error.value"),
+            "field signal should get .value, got: {out}"
+        );
+    }
+
+    // ── collect_param_names: object rest ───────────────────────────────
+
+    #[test]
+    fn collect_params_object_with_rest() {
+        let names = param_names("const f = ({ a, ...rest }) => {};");
+        assert!(names.contains("a"));
+        assert!(names.contains("rest"));
+    }
+
+    // ── collect_param_names: array rest ────────────────────────────────
+
+    #[test]
+    fn collect_params_array_with_rest() {
+        let names = param_names("const f = ([first, ...others]) => {};");
+        assert!(names.contains("first"));
+        assert!(names.contains("others"));
+    }
+
+    // ── Phase 2: member expression walk-through ───────────────────────
+
+    #[test]
+    fn signal_ref_through_member_expression() {
+        let out = transform(
+            "function C() { let items = []; const len = items.length; return <div>{len}</div>; }",
+        );
+        assert!(
+            out.contains("items.value.length"),
+            "member expression on signal should get .value on object, got: {out}"
+        );
+    }
+
+    // ── Phase 2: assignment to shadowed signal not transformed ────────
+
+    #[test]
+    fn assignment_to_shadowed_signal_not_transformed() {
+        let out = transform(
+            "function C() { let x = 0; const fn2 = (x) => { x = 5; }; return <div>{x}</div>; }",
+        );
+        // Inner `x = 5` where x is shadowed by param should NOT get .value
+        assert!(
+            out.contains("x = 5"),
+            "shadowed assignment should not get .value, got: {out}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add **166 Rust unit tests** across 4 core compiler modules to bring coverage from 38-60% to 95%+
- `context_stable_ids.rs`: 38.9% → **100%** (18 tests)
- `component_analyzer.rs`: 57.1% → **98.3%** (32 tests)  
- `signal_transformer.rs`: 60.3% → **95.9%** (34 tests)
- `reactivity_analyzer.rs`: 53.6% → **97.8%** (82 tests)

Covers: signal creation/tracking, dependency analysis, component boundary detection, destructured bindings, import alias resolution, manifest-derived APIs, transitive reactive dependencies, cycle detection, JSX reachability expansion, TS wrapper unwrapping, parameter shadowing, mutation ranges, and signal API property transforms.

Closes #10

## Test plan

- [x] All 166 new tests pass
- [x] All existing tests pass (2596 total)
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Coverage verified with `cargo llvm-cov`

🤖 Generated with [Claude Code](https://claude.com/claude-code)