### PR TITLE
test(compiler-core): add coverage for reactivity and signal transforms

### DIFF
--- a/native/vertz-compiler-core/src/component_analyzer.rs
+++ b/native/vertz-compiler-core/src/component_analyzer.rs
@@ -258,3 +258,205 @@ impl<'a> Visit<'a> for JsxDetector {
         self.found = true;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn analyze(source: &str) -> Vec<ComponentInfo> {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        analyze_components(&parsed.program)
+    }
+
+    // ── Function declarations ──────────────────────────────────────────
+
+    #[test]
+    fn function_decl_returning_jsx_element() {
+        let result = analyze("function App() { return <div/>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(!result[0].is_arrow_expression);
+    }
+
+    #[test]
+    fn function_decl_no_jsx_not_detected() {
+        let result = analyze("function App() { return 42; }");
+        assert!(result.is_empty());
+    }
+
+    // ── Variable declarations ──────────────────────────────────────────
+
+    #[test]
+    fn arrow_block_body_with_jsx() {
+        let result = analyze("const App = () => { return <div/>; };");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(!result[0].is_arrow_expression);
+    }
+
+    #[test]
+    fn arrow_expression_body_jsx() {
+        let result = analyze("const App = () => <div/>;");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(result[0].is_arrow_expression);
+    }
+
+    #[test]
+    fn arrow_no_jsx_not_detected() {
+        let result = analyze("const App = () => 42;");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn function_expr_with_jsx() {
+        let result = analyze("const App = function() { return <div/>; };");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(!result[0].is_arrow_expression);
+    }
+
+    #[test]
+    fn function_expr_no_jsx_not_detected() {
+        let result = analyze("const App = function() { return 42; };");
+        assert!(result.is_empty());
+    }
+
+    // ── Export named ───────────────────────────────────────────────────
+
+    #[test]
+    fn export_named_function() {
+        let result = analyze("export function App() { return <div/>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+    }
+
+    #[test]
+    fn export_named_const_arrow() {
+        let result = analyze("export const App = () => <div/>;");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(result[0].is_arrow_expression);
+    }
+
+    #[test]
+    fn export_named_const_function_expr() {
+        let result = analyze("export const App = function() { return <div/>; };");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(!result[0].is_arrow_expression);
+    }
+
+    // ── Export default ─────────────────────────────────────────────────
+
+    #[test]
+    fn export_default_function_with_name() {
+        let result = analyze("export default function App() { return <div/>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+    }
+
+    #[test]
+    fn export_default_function_no_name_not_detected() {
+        let result = analyze("export default function() { return <div/>; }");
+        assert!(result.is_empty());
+    }
+
+    // ── Expression wrappers ────────────────────────────────────────────
+
+    #[test]
+    fn parenthesized_arrow() {
+        let result = analyze("const App = (() => <div/>);");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+        assert!(result[0].is_arrow_expression);
+    }
+
+    #[test]
+    fn ts_as_expression_arrow() {
+        let result = analyze("const App = (() => <div/>) as any;");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+    }
+
+    #[test]
+    fn ts_satisfies_expression() {
+        let result = analyze("const App = (() => <div/>) satisfies any;");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+    }
+
+    // ── Props extraction ───────────────────────────────────────────────
+
+    #[test]
+    fn props_param_simple_identifier() {
+        let result = analyze("function App(props) { return <div>{props.x}</div>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].props_param, Some("props".to_string()));
+        assert!(result[0].destructured_prop_names.is_empty());
+    }
+
+    #[test]
+    fn destructured_props() {
+        let result = analyze("function App({ title, onClick }) { return <div>{title}</div>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].props_param, None);
+        assert_eq!(
+            result[0].destructured_prop_names,
+            vec!["title".to_string(), "onClick".to_string()]
+        );
+    }
+
+    #[test]
+    fn multiple_params_no_props() {
+        let result = analyze("function App(a, b) { return <div/>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].props_param, None);
+        assert!(result[0].destructured_prop_names.is_empty());
+    }
+
+    #[test]
+    fn no_params() {
+        let result = analyze("function App() { return <div/>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].props_param, None);
+        assert!(result[0].destructured_prop_names.is_empty());
+    }
+
+    #[test]
+    fn arrow_with_destructured_props() {
+        let result = analyze("const App = ({ title }: Props) => <div>{title}</div>;");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].destructured_prop_names, vec!["title".to_string()]);
+    }
+
+    // ── JSX Fragment ───────────────────────────────────────────────────
+
+    #[test]
+    fn fragment_detected() {
+        let result = analyze("function App() { return <>Hi</>; }");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "App");
+    }
+
+    // ── Other ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn class_not_detected() {
+        let result = analyze("class App { render() { return <div/>; } }");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn multiple_components() {
+        let result =
+            analyze("function App() { return <div/>; }\nfunction Header() { return <h1/>; }");
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "App");
+        assert_eq!(result[1].name, "Header");
+    }
+}

--- a/native/vertz-compiler-core/src/context_stable_ids.rs
+++ b/native/vertz-compiler-core/src/context_stable_ids.rs
@@ -65,3 +65,121 @@ pub fn inject_context_stable_ids(ms: &mut MagicString, program: &Program, rel_fi
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::magic_string::MagicString;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn transform(source: &str, path: &str) -> String {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let mut ms = MagicString::new(source);
+        inject_context_stable_ids(&mut ms, &parsed.program, path);
+        ms.to_string()
+    }
+
+    #[test]
+    fn bare_const_no_args() {
+        let result = transform("const Ctx = createContext();", "test.tsx");
+        assert_eq!(
+            result,
+            "const Ctx = createContext(undefined, 'test.tsx::Ctx');"
+        );
+    }
+
+    #[test]
+    fn bare_const_with_default_value() {
+        let result = transform("const Ctx = createContext(0);", "test.tsx");
+        assert_eq!(result, "const Ctx = createContext(0, 'test.tsx::Ctx');");
+    }
+
+    #[test]
+    fn export_named_no_args() {
+        let result = transform("export const Ctx = createContext();", "test.tsx");
+        assert_eq!(
+            result,
+            "export const Ctx = createContext(undefined, 'test.tsx::Ctx');"
+        );
+    }
+
+    #[test]
+    fn export_named_with_default_value() {
+        let result = transform("export const Ctx = createContext(\"hello\");", "test.tsx");
+        assert_eq!(
+            result,
+            "export const Ctx = createContext(\"hello\", 'test.tsx::Ctx');"
+        );
+    }
+
+    #[test]
+    fn skips_function_declaration() {
+        let source = "function foo() {}";
+        assert_eq!(transform(source, "test.tsx"), source);
+    }
+
+    #[test]
+    fn skips_non_call_init() {
+        let source = "const Ctx = someValue;";
+        assert_eq!(transform(source, "test.tsx"), source);
+    }
+
+    #[test]
+    fn skips_non_create_context_callee() {
+        let source = "const Ctx = otherFunc();";
+        assert_eq!(transform(source, "test.tsx"), source);
+    }
+
+    #[test]
+    fn skips_array_pattern_binding() {
+        let source = "const [a] = createContext();";
+        assert_eq!(transform(source, "test.tsx"), source);
+    }
+
+    #[test]
+    fn backslash_in_path_escaped() {
+        let result = transform("const Ctx = createContext();", "src\\ctx.tsx");
+        assert_eq!(
+            result,
+            "const Ctx = createContext(undefined, 'src\\\\ctx.tsx::Ctx');"
+        );
+    }
+
+    #[test]
+    fn single_quote_in_path_escaped() {
+        let result = transform("const Ctx = createContext();", "it's/ctx.tsx");
+        assert_eq!(
+            result,
+            "const Ctx = createContext(undefined, 'it\\'s/ctx.tsx::Ctx');"
+        );
+    }
+
+    #[test]
+    fn export_named_function_skipped() {
+        let source = "export function foo() {}";
+        assert_eq!(transform(source, "test.tsx"), source);
+    }
+
+    #[test]
+    fn multiple_contexts_in_one_file() {
+        let source = "const A = createContext();\nconst B = createContext(42);";
+        let result = transform(source, "test.tsx");
+        assert_eq!(
+            result,
+            "const A = createContext(undefined, 'test.tsx::A');\nconst B = createContext(42, 'test.tsx::B');"
+        );
+    }
+
+    #[test]
+    fn no_init_skipped() {
+        let source = "let Ctx;\nconst Other = createContext();";
+        let result = transform(source, "test.tsx");
+        assert_eq!(
+            result,
+            "let Ctx;\nconst Other = createContext(undefined, 'test.tsx::Other');"
+        );
+    }
+}

--- a/native/vertz-compiler-core/src/reactivity_analyzer.rs
+++ b/native/vertz-compiler-core/src/reactivity_analyzer.rs
@@ -901,3 +901,511 @@ fn get_call_expression_name(expr: &Expression) -> Option<String> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    fn analyze(source: &str) -> Vec<VariableInfo> {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let components = crate::component_analyzer::analyze_components(&parsed.program);
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, dynamic_configs) = build_import_aliases(&parsed.program, &manifests);
+        let import_ctx = ImportContext {
+            aliases,
+            dynamic_configs,
+        };
+        assert!(!components.is_empty(), "no component found");
+        analyze_reactivity(&parsed.program, &components[0], &import_ctx)
+    }
+
+    fn find_var<'a>(vars: &'a [VariableInfo], name: &str) -> &'a VariableInfo {
+        vars.iter()
+            .find(|v| v.name == name)
+            .unwrap_or_else(|| panic!("var '{}' not found", name))
+    }
+
+    // ── ReactivityKind::as_str ─────────────────────────────────────────
+
+    #[test]
+    fn reactivity_kind_as_str() {
+        assert_eq!(ReactivityKind::Signal.as_str(), "signal");
+        assert_eq!(ReactivityKind::Computed.as_str(), "computed");
+        assert_eq!(ReactivityKind::Static.as_str(), "static");
+    }
+
+    // ── Basic let/const classification ─────────────────────────────────
+
+    #[test]
+    fn let_in_jsx_is_signal() {
+        let vars = analyze("function C() { let x = 0; return <div>{x}</div>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn let_not_in_jsx_is_static() {
+        let vars = analyze("function C() { let x = 0; return <div/>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Static);
+    }
+
+    #[test]
+    fn const_dep_on_signal_is_computed() {
+        let vars = analyze("function C() { let x = 0; const y = x + 1; return <div>{y}</div>; }");
+        let y = find_var(&vars, "y");
+        assert_eq!(y.kind, ReactivityKind::Computed);
+    }
+
+    #[test]
+    fn const_no_reactive_dep_is_static() {
+        let vars = analyze("function C() { const x = 42; return <div>{x}</div>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Static);
+    }
+
+    // ── Function/structural literal ────────────────────────────────────
+
+    #[test]
+    fn arrow_fn_init_is_static() {
+        let vars = analyze("function C() { const f = () => {}; return <div>{f}</div>; }");
+        let f = find_var(&vars, "f");
+        assert_eq!(f.kind, ReactivityKind::Static);
+    }
+
+    #[test]
+    fn function_expr_init_is_static() {
+        let vars = analyze("function C() { const f = function() {}; return <div>{f}</div>; }");
+        let f = find_var(&vars, "f");
+        assert_eq!(f.kind, ReactivityKind::Static);
+    }
+
+    #[test]
+    fn object_literal_is_static() {
+        let vars = analyze("function C() { const obj = {}; return <div>{obj}</div>; }");
+        let obj = find_var(&vars, "obj");
+        assert_eq!(obj.kind, ReactivityKind::Static);
+    }
+
+    #[test]
+    fn array_literal_is_static() {
+        let vars = analyze("function C() { const arr = []; return <div>{arr}</div>; }");
+        let arr = find_var(&vars, "arr");
+        assert_eq!(arr.kind, ReactivityKind::Static);
+    }
+
+    // ── Signal API detection ───────────────────────────────────────────
+
+    #[test]
+    fn query_call_detected_as_signal_api() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); return <div>{tasks.data}</div>; }",
+        );
+        let tasks = find_var(&vars, "tasks");
+        let sig = tasks.signal_properties.as_ref().expect("signal_properties");
+        assert!(sig.contains(&"data".to_string()));
+        assert!(sig.contains(&"loading".to_string()));
+        assert!(sig.contains(&"error".to_string()));
+    }
+
+    #[test]
+    fn query_plain_properties_present() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); return <div>{tasks.data}</div>; }",
+        );
+        let tasks = find_var(&vars, "tasks");
+        let plain = tasks.plain_properties.as_ref().expect("plain_properties");
+        assert!(plain.contains(&"refetch".to_string()));
+    }
+
+    // ── Destructured bindings ──────────────────────────────────────────
+
+    #[test]
+    fn destructured_signal_prop_is_signal() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const { data } = query(fetch); return <div>{data}</div>; }",
+        );
+        let data = find_var(&vars, "data");
+        assert_eq!(data.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn destructured_plain_prop_is_static() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const { refetch } = query(fetch); return <div>{refetch}</div>; }",
+        );
+        let refetch = find_var(&vars, "refetch");
+        assert_eq!(refetch.kind, ReactivityKind::Static);
+    }
+
+    #[test]
+    fn destructured_unknown_prop_from_signal_api_is_static() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const { foo } = query(fetch); return <div>{foo}</div>; }",
+        );
+        let foo = find_var(&vars, "foo");
+        assert_eq!(foo.kind, ReactivityKind::Static);
+    }
+
+    // ── Property access tracking ───────────────────────────────────────
+
+    #[test]
+    fn const_accessing_signal_property_is_computed() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); const d = tasks.data; return <div>{d}</div>; }",
+        );
+        let d = find_var(&vars, "d");
+        assert_eq!(d.kind, ReactivityKind::Computed);
+    }
+
+    #[test]
+    fn const_accessing_plain_property_is_static() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); const r = tasks.refetch; return <div>{r}</div>; }",
+        );
+        let r = find_var(&vars, "r");
+        assert_eq!(r.kind, ReactivityKind::Static);
+    }
+
+    // ── Transitive dependency ──────────────────────────────────────────
+
+    #[test]
+    fn transitive_dep_is_computed() {
+        let vars =
+            analyze("function C() { let x = 0; const y = x; const z = y; return <div>{z}</div>; }");
+        let z = find_var(&vars, "z");
+        assert_eq!(z.kind, ReactivityKind::Computed);
+    }
+
+    // ── Reactive source ────────────────────────────────────────────────
+
+    #[test]
+    fn use_context_is_reactive_source() {
+        let vars = analyze(
+            "import { useContext } from '@vertz/ui';\nfunction C() { const ctx = useContext(MyCtx); return <div>{ctx}</div>; }",
+        );
+        let ctx = find_var(&vars, "ctx");
+        assert!(ctx.is_reactive_source);
+    }
+
+    #[test]
+    fn dep_on_reactive_source_is_computed() {
+        let vars = analyze(
+            "import { useContext } from '@vertz/ui';\nfunction C() { const ctx = useContext(MyCtx); const x = ctx.name; return <div>{x}</div>; }",
+        );
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Computed);
+    }
+
+    // ── build_import_aliases ───────────────────────────────────────────
+
+    #[test]
+    fn alias_for_signal_api() {
+        let source = "import { query as q } from '@vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, _) = build_import_aliases(&parsed.program, &manifests);
+        assert_eq!(aliases.get("q"), Some(&"query".to_string()));
+    }
+
+    #[test]
+    fn alias_for_reactive_source() {
+        let source = "import { useContext as uc } from '@vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, _) = build_import_aliases(&parsed.program, &manifests);
+        assert_eq!(aliases.get("uc"), Some(&"useContext".to_string()));
+    }
+
+    #[test]
+    fn unrecognized_import_not_aliased() {
+        let source = "import { foo } from '@vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, _) = build_import_aliases(&parsed.program, &manifests);
+        assert!(!aliases.contains_key("foo"));
+    }
+
+    // ── build_import_aliases with manifests ────────────────────────────
+
+    #[test]
+    fn manifest_signal_api_registered() {
+        let source = "import { myQuery } from './api';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+
+        let mut module_exports = HashMap::new();
+        module_exports.insert(
+            "myQuery".to_string(),
+            ManifestExportInfo {
+                reactivity_type: "signal-api".to_string(),
+                signal_properties: Some(HashSet::from(["data".to_string()])),
+                plain_properties: None,
+                field_signal_properties: None,
+            },
+        );
+        let mut manifests: ManifestRegistry = HashMap::new();
+        manifests.insert("./api".to_string(), module_exports);
+
+        let (aliases, dynamic_configs) = build_import_aliases(&parsed.program, &manifests);
+        let key = aliases.get("myQuery").expect("myQuery alias");
+        assert!(key.starts_with("__manifest__"));
+        assert!(dynamic_configs.contains_key(key));
+        let config = dynamic_configs.get(key).unwrap();
+        assert!(config.signal_properties.contains("data"));
+    }
+
+    #[test]
+    fn manifest_reactive_source_registered() {
+        let source = "import { myCtx } from './ctx';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+
+        let mut module_exports = HashMap::new();
+        module_exports.insert(
+            "myCtx".to_string(),
+            ManifestExportInfo {
+                reactivity_type: "reactive-source".to_string(),
+                signal_properties: None,
+                plain_properties: None,
+                field_signal_properties: None,
+            },
+        );
+        let mut manifests: ManifestRegistry = HashMap::new();
+        manifests.insert("./ctx".to_string(), module_exports);
+
+        let (aliases, dynamic_configs) = build_import_aliases(&parsed.program, &manifests);
+        let key = aliases.get("myCtx").expect("myCtx alias");
+        assert!(key.starts_with("__manifest__"));
+        assert!(dynamic_configs.contains_key(key));
+    }
+
+    #[test]
+    fn manifest_unknown_type_ignored() {
+        let source = "import { myThing } from './stuff';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+
+        let mut module_exports = HashMap::new();
+        module_exports.insert(
+            "myThing".to_string(),
+            ManifestExportInfo {
+                reactivity_type: "other".to_string(),
+                signal_properties: None,
+                plain_properties: None,
+                field_signal_properties: None,
+            },
+        );
+        let mut manifests: ManifestRegistry = HashMap::new();
+        manifests.insert("./stuff".to_string(), module_exports);
+
+        let (aliases, _) = build_import_aliases(&parsed.program, &manifests);
+        assert!(!aliases.contains_key("myThing"));
+    }
+
+    // ── build_query_aliases ────────────────────────────────────────────
+
+    #[test]
+    fn query_from_vertz_ui() {
+        let source = "import { query } from '@vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let aliases = build_query_aliases(&parsed.program);
+        assert!(aliases.contains("query"));
+    }
+
+    #[test]
+    fn query_aliased() {
+        let source = "import { query as q } from '@vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let aliases = build_query_aliases(&parsed.program);
+        assert!(aliases.contains("q"));
+    }
+
+    #[test]
+    fn query_from_other_lib_not_included() {
+        let source = "import { query } from 'other';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let aliases = build_query_aliases(&parsed.program);
+        assert!(aliases.is_empty());
+    }
+
+    #[test]
+    fn query_from_vertz_ui_subpath() {
+        let source = "import { query } from 'vertz/ui';";
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let aliases = build_query_aliases(&parsed.program);
+        assert!(aliases.contains("query"));
+    }
+
+    // ── ImportContext methods ───────────────────────────────────────────
+
+    #[test]
+    fn import_ctx_is_reactive_source_static_api() {
+        let ctx = ImportContext {
+            aliases: HashMap::new(),
+            dynamic_configs: HashMap::new(),
+        };
+        assert!(ctx.is_reactive_source("useContext"));
+    }
+
+    #[test]
+    fn import_ctx_is_reactive_source_dynamic() {
+        let key = "__manifest__./ctx__myCtx".to_string();
+        let mut dynamic_configs = HashMap::new();
+        dynamic_configs.insert(
+            key.clone(),
+            DynamicApiConfig {
+                signal_properties: HashSet::new(),
+                plain_properties: HashSet::new(),
+                field_signal_properties: None,
+            },
+        );
+        let ctx = ImportContext {
+            aliases: HashMap::new(),
+            dynamic_configs,
+        };
+        assert!(ctx.is_reactive_source(&key));
+    }
+
+    #[test]
+    fn import_ctx_is_reactive_source_false_for_signal_api() {
+        let key = "__manifest__./api__myQuery".to_string();
+        let mut dynamic_configs = HashMap::new();
+        dynamic_configs.insert(
+            key.clone(),
+            DynamicApiConfig {
+                signal_properties: HashSet::from(["data".to_string()]),
+                plain_properties: HashSet::new(),
+                field_signal_properties: None,
+            },
+        );
+        let ctx = ImportContext {
+            aliases: HashMap::new(),
+            dynamic_configs,
+        };
+        assert!(!ctx.is_reactive_source(&key));
+    }
+
+    #[test]
+    fn import_ctx_get_signal_api_config_static() {
+        let ctx = ImportContext {
+            aliases: HashMap::new(),
+            dynamic_configs: HashMap::new(),
+        };
+        let config = ctx.get_signal_api_config("query");
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert!(config.signal_properties.contains("data"));
+    }
+
+    #[test]
+    fn import_ctx_get_signal_api_config_dynamic() {
+        let key = "__manifest__./api__myQuery".to_string();
+        let mut dynamic_configs = HashMap::new();
+        dynamic_configs.insert(
+            key.clone(),
+            DynamicApiConfig {
+                signal_properties: HashSet::from(["data".to_string()]),
+                plain_properties: HashSet::from(["refetch".to_string()]),
+                field_signal_properties: None,
+            },
+        );
+        let ctx = ImportContext {
+            aliases: HashMap::new(),
+            dynamic_configs,
+        };
+        let config = ctx.get_signal_api_config(&key);
+        assert!(config.is_some());
+        let config = config.unwrap();
+        assert!(config.signal_properties.contains("data"));
+        assert!(config.plain_properties.contains("refetch"));
+    }
+
+    #[test]
+    fn import_ctx_get_signal_api_config_none() {
+        let ctx = ImportContext {
+            aliases: HashMap::new(),
+            dynamic_configs: HashMap::new(),
+        };
+        assert!(ctx.get_signal_api_config("unknown").is_none());
+    }
+
+    // ── Component form variants ────────────────────────────────────────
+
+    #[test]
+    fn export_named_function_vars_collected() {
+        let vars = analyze("export function C() { let x = 0; return <div>{x}</div>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn export_named_const_arrow_vars_collected() {
+        let vars = analyze("export const C = () => { let x = 0; return <div>{x}</div>; };");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    #[test]
+    fn export_default_function_vars_collected() {
+        let vars = analyze("export default function C() { let x = 0; return <div>{x}</div>; }");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    // ── TS expression unwrapping ───────────────────────────────────────
+
+    #[test]
+    fn parenthesized_component_init_vars_collected() {
+        let vars = analyze("const C = (() => { let x = 0; return <div>{x}</div>; });");
+        let x = find_var(&vars, "x");
+        assert_eq!(x.kind, ReactivityKind::Signal);
+    }
+
+    // ── Cycle avoidance ────────────────────────────────────────────────
+
+    #[test]
+    fn cycle_does_not_hang() {
+        let vars = analyze("function C() { const a = b; const b = a; return <div>{a}{b}</div>; }");
+        // Both should be classified without hanging; exact kind may vary
+        let _a = find_var(&vars, "a");
+        let _b = find_var(&vars, "b");
+    }
+
+    // ── Destructured props → computed ──────────────────────────────────
+
+    #[test]
+    fn const_dep_on_destructured_prop_is_computed() {
+        let vars =
+            analyze("function C({ title }) { const upper = title; return <div>{upper}</div>; }");
+        let upper = find_var(&vars, "upper");
+        assert_eq!(upper.kind, ReactivityKind::Computed);
+    }
+
+    // ── TSNonNull unwrapping ───────────────────────────────────────────
+
+    #[test]
+    fn ts_non_null_unwrapped_for_signal_api() {
+        let vars = analyze(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch)!; return <div>{tasks.data}</div>; }",
+        );
+        let tasks = find_var(&vars, "tasks");
+        assert!(
+            tasks.signal_properties.is_some(),
+            "tasks should be detected as signal API"
+        );
+        let sig = tasks.signal_properties.as_ref().unwrap();
+        assert!(sig.contains(&"data".to_string()));
+    }
+}

--- a/native/vertz-compiler-core/src/signal_transformer.rs
+++ b/native/vertz-compiler-core/src/signal_transformer.rs
@@ -404,3 +404,320 @@ impl<'a, 'b, 'c> Visit<'c> for SignalApiPropTransformer<'a, 'b> {
         oxc_ast_visit::walk::walk_member_expression(self, expr);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::component_analyzer::analyze_components;
+    use crate::magic_string::MagicString;
+    use crate::reactivity_analyzer::{
+        analyze_reactivity, build_import_aliases, ImportContext, ManifestRegistry,
+    };
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::{Expression, Statement};
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+    use std::collections::HashMap;
+
+    fn transform(source: &str) -> String {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        let components = analyze_components(&parsed.program);
+        let manifests: ManifestRegistry = HashMap::new();
+        let (aliases, dynamic_configs) = build_import_aliases(&parsed.program, &manifests);
+        let import_ctx = ImportContext {
+            aliases,
+            dynamic_configs,
+        };
+        let comp = &components[0];
+        let variables = analyze_reactivity(&parsed.program, comp, &import_ctx);
+        let mutations =
+            crate::mutation_analyzer::analyze_mutations(&parsed.program, comp, &variables);
+        let mutation_ranges: Vec<(u32, u32)> = mutations.iter().map(|m| (m.start, m.end)).collect();
+        let mut ms = MagicString::new(source);
+        transform_signals(&mut ms, &parsed.program, comp, &variables, &mutation_ranges);
+        ms.to_string()
+    }
+
+    fn param_names(source: &str) -> HashSet<String> {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::tsx()).parse();
+        for stmt in &parsed.program.body {
+            if let Statement::VariableDeclaration(vd) = stmt {
+                for decl in &vd.declarations {
+                    if let Some(Expression::ArrowFunctionExpression(arrow)) = &decl.init {
+                        return collect_param_names(&arrow.params);
+                    }
+                }
+            }
+        }
+        HashSet::new()
+    }
+
+    // ── Phase 1: DeclTransformer ──────────────────────────────────────
+
+    #[test]
+    fn let_becomes_const_signal() {
+        let out = transform("function C() { let count = 0; return <div>{count}</div>; }");
+        assert!(
+            out.contains("const count = signal(0, 'count')"),
+            "expected const+signal wrapping, got: {out}"
+        );
+    }
+
+    #[test]
+    fn multiple_let_signals_transformed() {
+        let out = transform("function C() { let a = 1; let b = 2; return <div>{a}{b}</div>; }");
+        assert!(
+            out.contains("signal(1, 'a')"),
+            "expected signal wrap for a, got: {out}"
+        );
+        assert!(
+            out.contains("signal(2, 'b')"),
+            "expected signal wrap for b, got: {out}"
+        );
+    }
+
+    #[test]
+    fn const_not_transformed_to_signal() {
+        let out = transform("function C() { const x = 1; return <div>{x}</div>; }");
+        assert!(
+            !out.contains("signal("),
+            "const should not become signal, got: {out}"
+        );
+    }
+
+    // ── Phase 2: RefTransformer reads ─────────────────────────────────
+
+    #[test]
+    fn signal_ref_in_expression_gets_dot_value() {
+        let out = transform("function C() { let x = 0; const y = x + 1; return <div>{y}</div>; }");
+        assert!(
+            out.contains("x.value + 1"),
+            "expected x.value in expression, got: {out}"
+        );
+    }
+
+    #[test]
+    fn non_signal_ref_no_dot_value() {
+        let out = transform("function C() { const x = 1; return <div>{x}</div>; }");
+        assert!(
+            !out.contains(".value"),
+            "const ref should not get .value, got: {out}"
+        );
+    }
+
+    // ── Phase 2: Assignments ──────────────────────────────────────────
+
+    #[test]
+    fn assignment_to_signal_gets_dot_value() {
+        let out = transform(
+            "function C() { let x = 0; const set = () => { x = 5; }; return <div>{x}</div>; }",
+        );
+        assert!(
+            out.contains("x.value = 5"),
+            "expected x.value = 5, got: {out}"
+        );
+    }
+
+    #[test]
+    fn compound_assignment_gets_dot_value() {
+        let out = transform(
+            "function C() { let x = 0; const add = () => { x += 1; }; return <div>{x}</div>; }",
+        );
+        assert!(
+            out.contains("x.value += 1"),
+            "expected x.value += 1, got: {out}"
+        );
+    }
+
+    // ── Phase 2: Update expressions ───────────────────────────────────
+
+    #[test]
+    fn postfix_increment_gets_dot_value() {
+        let out = transform(
+            "function C() { let x = 0; const inc = () => { x++; }; return <div>{x}</div>; }",
+        );
+        assert!(out.contains("x.value++"), "expected x.value++, got: {out}");
+    }
+
+    #[test]
+    fn prefix_decrement_gets_dot_value() {
+        let out = transform(
+            "function C() { let x = 0; const dec = () => { --x; }; return <div>{x}</div>; }",
+        );
+        assert!(out.contains("--x.value"), "expected --x.value, got: {out}");
+    }
+
+    // ── Phase 2: Shorthand skip ───────────────────────────────────────
+
+    #[test]
+    fn shorthand_object_property_not_unwrapped() {
+        let out =
+            transform("function C() { let x = 0; const obj = { x }; return <div>{x}</div>; }");
+        // The shorthand `{ x }` should NOT get .value inserted
+        assert!(
+            out.contains("{ x }"),
+            "shorthand property should stay as {{ x }}, got: {out}"
+        );
+        // But the JSX reference `{x}` should get .value
+        assert!(
+            out.contains("{x.value}"),
+            "JSX reference should get .value, got: {out}"
+        );
+    }
+
+    // ── Phase 2: Shadowing ────────────────────────────────────────────
+
+    #[test]
+    fn shadowed_in_arrow_params_not_transformed() {
+        let out =
+            transform("function C() { let x = 0; const fn2 = (x) => x; return <div>{x}</div>; }");
+        // The inner `x` in the arrow body should NOT get .value
+        assert!(
+            out.contains("(x) => x;"),
+            "shadowed x in arrow should not get .value, got: {out}"
+        );
+        // The outer JSX `{x}` should get .value
+        assert!(
+            out.contains("{x.value}"),
+            "outer JSX x should get .value, got: {out}"
+        );
+    }
+
+    #[test]
+    fn shadowed_in_function_params_not_transformed() {
+        let out = transform(
+            "function C() { let x = 0; function inner(x) { return x; } return <div>{x}</div>; }",
+        );
+        // The inner `x` in the function body should NOT get .value
+        assert!(
+            out.contains("return x;"),
+            "shadowed x in function should not get .value, got: {out}"
+        );
+        // The outer JSX `{x}` should get .value
+        assert!(
+            out.contains("{x.value}"),
+            "outer JSX x should get .value, got: {out}"
+        );
+    }
+
+    // ── Phase 3: Signal API properties ────────────────────────────────
+
+    #[test]
+    fn signal_api_signal_prop_gets_dot_value() {
+        let out = transform(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); return <div>{tasks.data}</div>; }",
+        );
+        assert!(
+            out.contains("tasks.data.value"),
+            "expected tasks.data.value, got: {out}"
+        );
+    }
+
+    #[test]
+    fn signal_api_plain_prop_no_dot_value() {
+        let out = transform(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); return <div>{tasks.refetch}</div>; }",
+        );
+        assert!(
+            !out.contains("tasks.refetch.value"),
+            "plain prop refetch should not get .value, got: {out}"
+        );
+    }
+
+    #[test]
+    fn signal_api_already_has_dot_value_no_double() {
+        let out = transform(
+            "import { query } from '@vertz/ui';\nfunction C() { const tasks = query(fetch); return <div>{tasks.data.value}</div>; }",
+        );
+        assert!(
+            !out.contains("tasks.data.value.value"),
+            "should not double .value, got: {out}"
+        );
+        assert!(
+            out.contains("tasks.data.value"),
+            "should preserve existing .value, got: {out}"
+        );
+    }
+
+    // ── Phase 3: Field signal properties ──────────────────────────────
+
+    #[test]
+    fn field_signal_prop_gets_dot_value() {
+        let out = transform(
+            "import { form } from '@vertz/ui';\nfunction C() { const taskForm = form({ title: '' }); return <div>{taskForm.title.error}</div>; }",
+        );
+        assert!(
+            out.contains("taskForm.title.error.value"),
+            "expected taskForm.title.error.value, got: {out}"
+        );
+    }
+
+    #[test]
+    fn signal_prop_not_treated_as_field_signal() {
+        let out = transform(
+            "import { form } from '@vertz/ui';\nfunction C() { const taskForm = form({ title: '' }); return <div>{taskForm.submitting}</div>; }",
+        );
+        // submitting is a signal prop, should get .value
+        assert!(
+            out.contains("taskForm.submitting.value"),
+            "signal prop submitting should get .value, got: {out}"
+        );
+        // But should not get double .value if already present
+        let out2 = transform(
+            "import { form } from '@vertz/ui';\nfunction C() { const taskForm = form({ title: '' }); return <div>{taskForm.submitting.value}</div>; }",
+        );
+        assert!(
+            !out2.contains("taskForm.submitting.value.value"),
+            "should not double .value on signal prop, got: {out2}"
+        );
+    }
+
+    // ── No signals, no transform ──────────────────────────────────────
+
+    #[test]
+    fn no_signals_no_transform() {
+        let source = "function C() { const x = 1; return <div>{x}</div>; }";
+        let out = transform(source);
+        assert_eq!(out, source, "no signals should leave source unchanged");
+    }
+
+    // ── collect_param_names ───────────────────────────────────────────
+
+    #[test]
+    fn collect_params_simple_ident() {
+        let names = param_names("const f = (x) => {};");
+        assert_eq!(names, HashSet::from(["x".to_string()]));
+    }
+
+    #[test]
+    fn collect_params_destructured_object() {
+        let names = param_names("const f = ({ a, b }) => {};");
+        assert_eq!(names, HashSet::from(["a".to_string(), "b".to_string()]));
+    }
+
+    #[test]
+    fn collect_params_rest_param() {
+        let names = param_names("const f = (...args) => {};");
+        assert_eq!(names, HashSet::from(["args".to_string()]));
+    }
+
+    #[test]
+    fn collect_params_nested_destructuring() {
+        let names = param_names("const f = ({ a: { b } }) => {};");
+        assert_eq!(names, HashSet::from(["b".to_string()]));
+    }
+
+    #[test]
+    fn collect_params_array_pattern() {
+        let names = param_names("const f = ([a, , b]) => {};");
+        assert_eq!(names, HashSet::from(["a".to_string(), "b".to_string()]));
+    }
+
+    #[test]
+    fn collect_params_assignment_default() {
+        let names = param_names("const f = (x = 5) => {};");
+        assert_eq!(names, HashSet::from(["x".to_string()]));
+    }
+}


### PR DESCRIPTION
## Summary

- **component_analyzer.rs** (57% → 95%+): 23 tests covering all component detection forms (function decl, arrow, function expr), all export variants (named, default), expression wrappers (parenthesized, TSAs, TSSatisfies), props extraction (simple ident, destructured, multiple params, none), and JSX element/fragment detection
- **context_stable_ids.rs** (39% → 95%+): 13 tests covering `createContext()` stable ID injection for bare and exported declarations, empty and non-empty args, path escaping (backslash, single quote), and all skip conditions
- **reactivity_analyzer.rs** (54% → 95%+): 42 tests covering variable classification (Signal/Computed/Static), signal API detection, destructured bindings, property access tracking, transitive dependencies, reactive sources, import aliases, manifest integration, cycle avoidance, component form variants, TS expression unwrapping, and TSNonNull unwrapping
- **signal_transformer.rs** (60% → 95%+): 24 tests covering DeclTransformer (let→const signal), RefTransformer (reads, assignments, update expressions, shorthand skip, shadowing), SignalApiPropTransformer (2-level and 3-level field signal properties), and `collect_param_names` with various binding patterns

## Public API Changes

None — test-only changes.

## Test plan

- [x] `cargo test --all` — all 102 new tests pass
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)