### PR TITLE
test(runtime): add coverage for fetch.rs and crypto_subtle.rs

### DIFF
--- a/native/vtz/src/runtime/ops/crypto_subtle.rs
+++ b/native/vtz/src/runtime/ops/crypto_subtle.rs
@@ -1747,4 +1747,1628 @@ mod tests {
         .await;
         assert_eq!(result, serde_json::json!("correct-error"));
     }
+
+    // --- digest: SHA-1 and SHA-384 ---
+
+    #[tokio::test]
+    async fn test_digest_sha1() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const hash = await crypto.subtle.digest('SHA-1', new TextEncoder().encode('abc'));
+            return new Uint8Array(hash).length;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(20)); // SHA-1 = 160 bits = 20 bytes
+    }
+
+    #[tokio::test]
+    async fn test_digest_sha384() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const hash = await crypto.subtle.digest('SHA-384', new TextEncoder().encode('abc'));
+            return new Uint8Array(hash).length;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(48)); // SHA-384 = 384 bits = 48 bytes
+    }
+
+    // --- HMAC import errors ---
+
+    #[tokio::test]
+    async fn test_hmac_import_non_raw_format_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'pkcs8', new Uint8Array(32),
+                    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('raw') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_hmac_import_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(32),
+                    { name: 'HMAC' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_hmac_import_unsupported_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(32),
+                    { name: 'HMAC', hash: 'MD5' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('MD5') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- AES-GCM import ---
+
+    #[tokio::test]
+    async fn test_aes_gcm_import_raw() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const rawKey = new Uint8Array(32);
+            crypto.getRandomValues(rawKey);
+            const key = await crypto.subtle.importKey(
+                'raw', rawKey, { name: 'AES-GCM' }, true, ['encrypt', 'decrypt']
+            );
+            return [
+                key.type === 'secret',
+                key.algorithm.name === 'AES-GCM',
+                key.extractable === true
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(item.as_bool().unwrap(), "AES-GCM import check {} failed", i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_aes_gcm_import_non_raw_format_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'pkcs8', new Uint8Array(32),
+                    { name: 'AES-GCM' }, false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('raw') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_aes_gcm_import_wrong_key_size_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(24),
+                    { name: 'AES-GCM' }, false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('128 or 256 bits') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_aes_gcm_import_128_bit_key() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const rawKey = new Uint8Array(16);
+            crypto.getRandomValues(rawKey);
+            const key = await crypto.subtle.importKey(
+                'raw', rawKey, { name: 'AES-GCM' }, false, ['encrypt', 'decrypt']
+            );
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const ct = await crypto.subtle.encrypt(
+                { name: 'AES-GCM', iv }, key, new TextEncoder().encode('test')
+            );
+            const pt = await crypto.subtle.decrypt(
+                { name: 'AES-GCM', iv }, key, ct
+            );
+            return new TextDecoder().decode(new Uint8Array(pt)) === 'test';
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    // --- AES-GCM encrypt/decrypt edge cases ---
+
+    #[tokio::test]
+    async fn test_aes_gcm_with_additional_data() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
+            );
+            const iv = crypto.getRandomValues(new Uint8Array(12));
+            const aad = new TextEncoder().encode('associated data');
+            const ct = await crypto.subtle.encrypt(
+                { name: 'AES-GCM', iv, additionalData: aad }, key,
+                new TextEncoder().encode('secret')
+            );
+            // Decrypt with same AAD should work
+            const pt = await crypto.subtle.decrypt(
+                { name: 'AES-GCM', iv, additionalData: aad }, key, ct
+            );
+            const decoded = new TextDecoder().decode(new Uint8Array(pt));
+            // Decrypt with different AAD should fail
+            let wrongAadFailed = false;
+            try {
+                await crypto.subtle.decrypt(
+                    { name: 'AES-GCM', iv, additionalData: new TextEncoder().encode('wrong') },
+                    key, ct
+                );
+            } catch (e) { wrongAadFailed = true; }
+            return [decoded === 'secret', wrongAadFailed];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert!(arr[0].as_bool().unwrap(), "should decrypt with correct AAD");
+        assert!(arr[1].as_bool().unwrap(), "should fail with wrong AAD");
+    }
+
+    #[tokio::test]
+    async fn test_aes_gcm_wrong_iv_size_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['encrypt']
+            );
+            try {
+                await crypto.subtle.encrypt(
+                    { name: 'AES-GCM', iv: new Uint8Array(8) }, key,
+                    new TextEncoder().encode('test')
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('12 bytes') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_encrypt_non_aes_gcm_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['encrypt']
+            );
+            try {
+                await crypto.subtle.encrypt(
+                    { name: 'RSA-OAEP', iv: new Uint8Array(12) }, key,
+                    new TextEncoder().encode('test')
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('AES-GCM') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_decrypt_non_aes_gcm_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['decrypt']
+            );
+            try {
+                await crypto.subtle.decrypt(
+                    { name: 'RSA-OAEP', iv: new Uint8Array(12) }, key,
+                    new Uint8Array(32)
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('AES-GCM') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_encrypt_wrong_usage_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['decrypt']
+            );
+            try {
+                await crypto.subtle.encrypt(
+                    { name: 'AES-GCM', iv: new Uint8Array(12) }, key,
+                    new TextEncoder().encode('test')
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('encrypt') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_decrypt_wrong_usage_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 256 }, false, ['encrypt']
+            );
+            try {
+                await crypto.subtle.decrypt(
+                    { name: 'AES-GCM', iv: new Uint8Array(12) }, key,
+                    new Uint8Array(32)
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('decrypt') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- AES-GCM generateKey edge cases ---
+
+    #[tokio::test]
+    async fn test_generate_key_aes_gcm_128() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'AES-GCM', length: 128 }, true, ['encrypt', 'decrypt']
+            );
+            const exported = await crypto.subtle.exportKey('raw', key);
+            return new Uint8Array(exported).length;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(16)); // 128 bits = 16 bytes
+    }
+
+    #[tokio::test]
+    async fn test_generate_key_aes_gcm_missing_length_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'AES-GCM' }, false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('length') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_key_aes_gcm_invalid_length_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'AES-GCM', length: 192 }, false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('128 or 256') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_key_unsupported_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'ChaCha20' }, false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('generateKey') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- HMAC generateKey with different hashes ---
+
+    #[tokio::test]
+    async fn test_hmac_generate_key_sha512() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-512' }, true, ['sign', 'verify']
+            );
+            const exported = await crypto.subtle.exportKey('raw', key);
+            const data = new TextEncoder().encode('test');
+            const sig = await crypto.subtle.sign('HMAC', key, data);
+            const valid = await crypto.subtle.verify('HMAC', key, sig, data);
+            return [
+                new Uint8Array(exported).length === 128,
+                sig.byteLength > 0,
+                valid
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert!(
+            arr[0].as_bool().unwrap(),
+            "SHA-512 HMAC key should be 128 bytes"
+        );
+        assert!(arr[1].as_bool().unwrap(), "signature should have bytes");
+        assert!(arr[2].as_bool().unwrap(), "signature should verify");
+    }
+
+    #[tokio::test]
+    async fn test_hmac_generate_key_sha384() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-384' }, true, ['sign', 'verify']
+            );
+            const exported = await crypto.subtle.exportKey('raw', key);
+            return new Uint8Array(exported).length === 128;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn test_hmac_generate_key_sha1() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-1' }, true, ['sign']
+            );
+            const exported = await crypto.subtle.exportKey('raw', key);
+            return new Uint8Array(exported).length === 64;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn test_hmac_generate_key_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'HMAC' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- ECDSA P-384 ---
+
+    #[tokio::test]
+    async fn test_ecdsa_p384_sign_verify() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: 'P-384' }, false, ['sign', 'verify']
+            );
+            const data = new TextEncoder().encode('test data');
+            const sig = await crypto.subtle.sign(
+                { name: 'ECDSA', hash: 'SHA-384' }, keyPair.privateKey, data
+            );
+            const valid = await crypto.subtle.verify(
+                { name: 'ECDSA', hash: 'SHA-384' }, keyPair.publicKey, sig, data
+            );
+            return [
+                keyPair.privateKey.type === 'private',
+                keyPair.publicKey.type === 'public',
+                sig.byteLength > 0,
+                valid
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(item.as_bool().unwrap(), "ECDSA P-384 check {} failed", i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_generate_unsupported_curve_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'ECDSA', namedCurve: 'P-521' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('P-521') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_generate_missing_curve_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'ECDSA' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('namedCurve') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_sign_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign', 'verify']
+            );
+            try {
+                await crypto.subtle.sign(
+                    { name: 'ECDSA' }, keyPair.privateKey, new Uint8Array([1,2,3])
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_verify_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign', 'verify']
+            );
+            try {
+                await crypto.subtle.verify(
+                    { name: 'ECDSA' }, keyPair.publicKey, new Uint8Array(64), new Uint8Array([1,2,3])
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_unsupported_curve_hash_combo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: 'P-256' }, false, ['sign', 'verify']
+            );
+            try {
+                await crypto.subtle.sign(
+                    { name: 'ECDSA', hash: 'SHA-384' }, keyPair.privateKey, new Uint8Array([1,2,3])
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('curve/hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- ECDSA import ---
+
+    #[tokio::test]
+    async fn test_ecdsa_import_export_roundtrip() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']
+            );
+            // Export public key as raw
+            const pubRaw = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+            // Export private key as pkcs8
+            const privPkcs8 = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
+            // Re-import
+            const importedPub = await crypto.subtle.importKey(
+                'raw', pubRaw, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['verify']
+            );
+            const importedPriv = await crypto.subtle.importKey(
+                'pkcs8', privPkcs8, { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign']
+            );
+            // Sign with reimported private, verify with reimported public
+            const data = new TextEncoder().encode('roundtrip');
+            const sig = await crypto.subtle.sign(
+                { name: 'ECDSA', hash: 'SHA-256' }, importedPriv, data
+            );
+            const valid = await crypto.subtle.verify(
+                { name: 'ECDSA', hash: 'SHA-256' }, importedPub, sig, data
+            );
+            return [
+                importedPub.type === 'public',
+                importedPriv.type === 'private',
+                valid
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(
+                item.as_bool().unwrap(),
+                "ECDSA import roundtrip check {} failed",
+                i
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_import_unsupported_format_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'spki', new Uint8Array(65),
+                    { name: 'ECDSA', namedCurve: 'P-256' }, false, ['verify']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('pkcs8') && e.message.includes('raw') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_import_missing_curve_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(65),
+                    { name: 'ECDSA' }, false, ['verify']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('namedCurve') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_ecdsa_import_unsupported_curve_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(65),
+                    { name: 'ECDSA', namedCurve: 'P-521' }, false, ['verify']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('P-521') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- RSA generate + sign/verify ---
+
+    #[tokio::test]
+    async fn test_rsa_generate_sign_verify_sha256() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256', modulusLength: 2048 },
+                true, ['sign', 'verify']
+            );
+            const data = new TextEncoder().encode('RSA test');
+            const sig = await crypto.subtle.sign(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.privateKey, data
+            );
+            const valid = await crypto.subtle.verify(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.publicKey, sig, data
+            );
+            const invalid = await crypto.subtle.verify(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.publicKey, sig,
+                new TextEncoder().encode('wrong')
+            );
+            return [
+                keyPair.privateKey.type === 'private',
+                keyPair.publicKey.type === 'public',
+                sig.byteLength === 256,
+                valid, !invalid
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(item.as_bool().unwrap(), "RSA SHA-256 check {} failed", i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rsa_sign_verify_sha384() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384', modulusLength: 2048 },
+                false, ['sign', 'verify']
+            );
+            const data = new TextEncoder().encode('SHA-384 test');
+            const sig = await crypto.subtle.sign(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.privateKey, data
+            );
+            const valid = await crypto.subtle.verify(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.publicKey, sig, data
+            );
+            return [sig.byteLength === 256, valid];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert!(arr[0].as_bool().unwrap(), "RSA-384 sig should be 256 bytes");
+        assert!(arr[1].as_bool().unwrap(), "RSA-384 should verify");
+    }
+
+    #[tokio::test]
+    async fn test_rsa_sign_verify_sha512() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-512', modulusLength: 2048 },
+                false, ['sign', 'verify']
+            );
+            const data = new TextEncoder().encode('SHA-512 test');
+            const sig = await crypto.subtle.sign(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.privateKey, data
+            );
+            const valid = await crypto.subtle.verify(
+                { name: 'RSASSA-PKCS1-v1_5' }, keyPair.publicKey, sig, data
+            );
+            return [sig.byteLength === 256, valid];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert!(arr[0].as_bool().unwrap(), "RSA-512 sig should be 256 bytes");
+        assert!(arr[1].as_bool().unwrap(), "RSA-512 should verify");
+    }
+
+    // --- RSA import/export ---
+
+    #[tokio::test]
+    async fn test_rsa_import_export_roundtrip() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256', modulusLength: 2048 },
+                true, ['sign', 'verify']
+            );
+            // Export
+            const privPkcs8 = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
+            const pubSpki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+            // Re-import
+            const importedPriv = await crypto.subtle.importKey(
+                'pkcs8', privPkcs8,
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['sign']
+            );
+            const importedPub = await crypto.subtle.importKey(
+                'spki', pubSpki,
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, true, ['verify']
+            );
+            // Sign with reimported key, verify with reimported key
+            const data = new TextEncoder().encode('roundtrip');
+            const sig = await crypto.subtle.sign(
+                { name: 'RSASSA-PKCS1-v1_5' }, importedPriv, data
+            );
+            const valid = await crypto.subtle.verify(
+                { name: 'RSASSA-PKCS1-v1_5' }, importedPub, sig, data
+            );
+            return [
+                importedPriv.type === 'private',
+                importedPub.type === 'public',
+                valid
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(
+                item.as_bool().unwrap(),
+                "RSA import roundtrip check {} failed",
+                i
+            );
+        }
+    }
+
+    // --- RSA error paths ---
+
+    #[tokio::test]
+    async fn test_rsa_generate_sha1_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-1', modulusLength: 2048 },
+                    false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('SHA-1') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_rsa_generate_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048 },
+                    false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_rsa_generate_unsupported_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.generateKey(
+                    { name: 'RSASSA-PKCS1-v1_5', hash: 'MD5', modulusLength: 2048 },
+                    false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('MD5') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_rsa_import_unsupported_format_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(256),
+                    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('pkcs8') && e.message.includes('spki') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_rsa_import_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'pkcs8', new Uint8Array(256),
+                    { name: 'RSASSA-PKCS1-v1_5' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_rsa_import_sha1_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'pkcs8', new Uint8Array(256),
+                    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-1' }, false, ['sign']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('SHA-1') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- sign/verify unsupported algorithms ---
+
+    #[tokio::test]
+    async fn test_sign_unsupported_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']
+            );
+            try {
+                await crypto.subtle.sign(
+                    { name: 'ChaCha20' }, key, new Uint8Array([1,2,3])
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('sign') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_unsupported_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']
+            );
+            try {
+                await crypto.subtle.verify(
+                    { name: 'ChaCha20' }, key, new Uint8Array(32), new Uint8Array([1,2,3])
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('verify') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- importKey unsupported algorithm ---
+
+    #[tokio::test]
+    async fn test_import_unsupported_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'raw', new Uint8Array(32),
+                    { name: 'ChaCha20' }, false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('importKey') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- exportKey unsupported format ---
+
+    #[tokio::test]
+    async fn test_export_unsupported_format_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-256' }, true, ['sign']
+            );
+            try {
+                await crypto.subtle.exportKey('pkcs8', key);
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('format') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- Key not found ---
+
+    #[tokio::test]
+    async fn test_sign_key_not_found() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                // Use internal op directly with a bogus key ID
+                const result = Deno.core.ops.op_crypto_subtle_sign({
+                    algorithm: { name: 'HMAC' },
+                    keyId: 9999,
+                    data: Array.from(new Uint8Array([1,2,3]))
+                });
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('not found') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_key_not_found() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                const result = Deno.core.ops.op_crypto_subtle_verify({
+                    algorithm: { name: 'HMAC' },
+                    keyId: 9999,
+                    signature: Array.from(new Uint8Array(32)),
+                    data: Array.from(new Uint8Array([1,2,3]))
+                });
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('not found') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_export_key_not_found() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                const result = Deno.core.ops.op_crypto_subtle_export_key({
+                    format: 'raw',
+                    keyId: 9999
+                });
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('not found') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- HKDF edge cases ---
+
+    #[tokio::test]
+    async fn test_hkdf_import_key() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('secret'),
+                { name: 'HKDF' }, false, ['deriveBits', 'deriveKey']
+            );
+            return [
+                key.type === 'secret',
+                key.algorithm.name === 'HKDF',
+                key.extractable === false
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(item.as_bool().unwrap(), "HKDF import check {} failed", i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_hkdf_import_non_raw_format_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await crypto.subtle.importKey(
+                    'pkcs8', new Uint8Array(32),
+                    { name: 'HKDF' }, false, ['deriveBits']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('raw') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_hkdf_derive_bits_sha384() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key material'),
+                { name: 'HKDF' }, false, ['deriveBits']
+            );
+            const bits = await crypto.subtle.deriveBits(
+                { name: 'HKDF', hash: 'SHA-384',
+                  salt: new TextEncoder().encode('salt'),
+                  info: new TextEncoder().encode('info') },
+                ikm, 256
+            );
+            return bits.byteLength === 32;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn test_hkdf_derive_bits_sha512() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key material'),
+                { name: 'HKDF' }, false, ['deriveBits']
+            );
+            const bits = await crypto.subtle.deriveBits(
+                { name: 'HKDF', hash: 'SHA-512',
+                  salt: new TextEncoder().encode('salt'),
+                  info: new TextEncoder().encode('info') },
+                ikm, 512
+            );
+            return bits.byteLength === 64;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn test_hkdf_derive_bits_unsupported_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key'),
+                { name: 'HKDF' }, false, ['deriveBits']
+            );
+            try {
+                await crypto.subtle.deriveBits(
+                    { name: 'HKDF', hash: 'MD5',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    ikm, 256
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('MD5') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_hkdf_derive_bits_missing_hash_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key'),
+                { name: 'HKDF' }, false, ['deriveBits']
+            );
+            try {
+                await crypto.subtle.deriveBits(
+                    { name: 'HKDF',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    ikm, 256
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('hash') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_derive_bits_wrong_usage_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key'),
+                { name: 'HKDF' }, false, ['deriveKey']
+            );
+            try {
+                await crypto.subtle.deriveBits(
+                    { name: 'HKDF', hash: 'SHA-256',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    ikm, 256
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('deriveBits') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_derive_bits_non_hkdf_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-256' }, false, ['deriveBits']
+            );
+            try {
+                await crypto.subtle.deriveBits(
+                    { name: 'PBKDF2', hash: 'SHA-256',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    key, 256
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('HKDF') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- deriveKey edge cases ---
+
+    #[tokio::test]
+    async fn test_hkdf_derive_key_to_hmac() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('password'),
+                { name: 'HKDF' }, false, ['deriveKey']
+            );
+            const key = await crypto.subtle.deriveKey(
+                { name: 'HKDF', hash: 'SHA-256',
+                  salt: new TextEncoder().encode('salt'),
+                  info: new TextEncoder().encode('info') },
+                ikm,
+                { name: 'HMAC', hash: 'SHA-256', length: 256 },
+                true, ['sign', 'verify']
+            );
+            const data = new TextEncoder().encode('test');
+            const sig = await crypto.subtle.sign('HMAC', key, data);
+            const valid = await crypto.subtle.verify('HMAC', key, sig, data);
+            return [
+                key.type === 'secret',
+                key.algorithm.name === 'HMAC',
+                valid
+            ];
+        "#,
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        for (i, item) in arr.iter().enumerate() {
+            assert!(
+                item.as_bool().unwrap(),
+                "HKDF deriveKey→HMAC check {} failed",
+                i
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_derive_key_wrong_usage_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key'),
+                { name: 'HKDF' }, false, ['deriveBits']
+            );
+            try {
+                await crypto.subtle.deriveKey(
+                    { name: 'HKDF', hash: 'SHA-256',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    ikm,
+                    { name: 'AES-GCM', length: 256 },
+                    false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('deriveKey') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_derive_key_non_hkdf_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-256' }, false, ['deriveKey']
+            );
+            try {
+                await crypto.subtle.deriveKey(
+                    { name: 'PBKDF2', hash: 'SHA-256',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    key,
+                    { name: 'AES-GCM', length: 256 },
+                    false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('HKDF') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    #[tokio::test]
+    async fn test_derive_key_unsupported_derived_algo_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key'),
+                { name: 'HKDF' }, false, ['deriveKey']
+            );
+            try {
+                await crypto.subtle.deriveKey(
+                    { name: 'HKDF', hash: 'SHA-256',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    ikm,
+                    { name: 'ChaCha20', length: 256 },
+                    false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('deriveKey') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- ECDSA export public key as raw ---
+
+    #[tokio::test]
+    async fn test_ecdsa_export_public_key_raw() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']
+            );
+            const pubRaw = await crypto.subtle.exportKey('raw', keyPair.publicKey);
+            // P-256 uncompressed public key = 65 bytes (0x04 prefix + 32 + 32)
+            return new Uint8Array(pubRaw).length === 65;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    // --- RSA export formats ---
+
+    #[tokio::test]
+    async fn test_rsa_export_public_key_spki() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256', modulusLength: 2048 },
+                true, ['sign', 'verify']
+            );
+            const spki = await crypto.subtle.exportKey('spki', keyPair.publicKey);
+            return spki.byteLength > 0;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    #[tokio::test]
+    async fn test_rsa_export_private_key_pkcs8() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const keyPair = await crypto.subtle.generateKey(
+                { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256', modulusLength: 2048 },
+                true, ['sign', 'verify']
+            );
+            const pkcs8 = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
+            return pkcs8.byteLength > 0;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    // --- HMAC with custom key length ---
+
+    #[tokio::test]
+    async fn test_hmac_generate_key_custom_length() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const key = await crypto.subtle.generateKey(
+                { name: 'HMAC', hash: 'SHA-256', length: 128 }, true, ['sign']
+            );
+            const exported = await crypto.subtle.exportKey('raw', key);
+            return new Uint8Array(exported).length === 16;
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!(true));
+    }
+
+    // --- AES-GCM deriveKey missing length ---
+
+    #[tokio::test]
+    async fn test_derive_key_aes_gcm_missing_length_fails() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            const ikm = await crypto.subtle.importKey(
+                'raw', new TextEncoder().encode('key'),
+                { name: 'HKDF' }, false, ['deriveKey']
+            );
+            try {
+                await crypto.subtle.deriveKey(
+                    { name: 'HKDF', hash: 'SHA-256',
+                      salt: new Uint8Array(), info: new Uint8Array() },
+                    ikm,
+                    { name: 'AES-GCM' },
+                    false, ['encrypt']
+                );
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('length') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
 }

--- a/native/vtz/src/runtime/ops/fetch.rs
+++ b/native/vtz/src/runtime/ops/fetch.rs
@@ -91,3 +91,308 @@ pub const FETCH_BOOTSTRAP_JS: &str = r#"
   // We keep this file's bootstrap empty since web_api handles everything.
 })(globalThis);
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::js_runtime::{VertzJsRuntime, VertzRuntimeOptions};
+    use axum::{
+        body::Body,
+        extract::Request,
+        http::StatusCode,
+        response::IntoResponse,
+        routing::{get, post},
+        Router,
+    };
+    use tokio::net::TcpListener;
+
+    fn create_runtime() -> VertzJsRuntime {
+        VertzJsRuntime::new(VertzRuntimeOptions::default()).unwrap()
+    }
+
+    /// Helper: run async JS, store result in globalThis.__result, return it.
+    async fn run_async(rt: &mut VertzJsRuntime, code: &str) -> serde_json::Value {
+        let wrapped = format!(
+            r#"(async () => {{ {} }})().then(v => {{ globalThis.__result = v; }}).catch(e => {{ globalThis.__result = 'ERROR: ' + e.message; }})"#,
+            code
+        );
+        rt.execute_script_void("<test>", &wrapped).unwrap();
+        rt.run_event_loop().await.unwrap();
+        rt.execute_script("<read>", "globalThis.__result").unwrap()
+    }
+
+    /// Start a test HTTP server on a random port and return its base URL.
+    async fn start_test_server(app: Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    fn simple_app() -> Router {
+        Router::new()
+            .route("/hello", get(|| async { "Hello, World!" }))
+            .route(
+                "/json",
+                get(|| async {
+                    (
+                        StatusCode::OK,
+                        [("content-type", "application/json")],
+                        r#"{"key":"value"}"#,
+                    )
+                }),
+            )
+            .route(
+                "/echo",
+                post(|req: Request<Body>| async move {
+                    let headers = req.headers().clone();
+                    let body_bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+                        .await
+                        .unwrap();
+                    let body_str = String::from_utf8_lossy(&body_bytes).to_string();
+                    let ct = headers
+                        .get("content-type")
+                        .map(|v| v.to_str().unwrap_or(""))
+                        .unwrap_or("");
+                    let custom = headers
+                        .get("x-custom")
+                        .map(|v| v.to_str().unwrap_or(""))
+                        .unwrap_or("");
+                    (
+                        StatusCode::OK,
+                        [
+                            ("x-echo-content-type", ct.to_string()),
+                            ("x-echo-custom", custom.to_string()),
+                        ],
+                        body_str,
+                    )
+                        .into_response()
+                }),
+            )
+            .route(
+                "/not-found",
+                get(|| async { (StatusCode::NOT_FOUND, "Not Found") }),
+            )
+            .route(
+                "/server-error",
+                get(|| async { (StatusCode::INTERNAL_SERVER_ERROR, "Internal Error") }),
+            )
+    }
+
+    // --- GET request: body, status, statusText ---
+
+    #[tokio::test]
+    async fn test_fetch_get_returns_body_and_status() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/hello');
+                return [resp.status, resp.statusText, await resp.text()];
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_u64().unwrap(), 200);
+        assert_eq!(arr[1].as_str().unwrap(), "OK");
+        assert_eq!(arr[2].as_str().unwrap(), "Hello, World!");
+    }
+
+    // --- GET returns response headers ---
+
+    #[tokio::test]
+    async fn test_fetch_get_returns_headers() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/json');
+                return resp.headers.get('content-type');
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        assert_eq!(result.as_str().unwrap(), "application/json");
+    }
+
+    // --- POST with string body ---
+
+    #[tokio::test]
+    async fn test_fetch_post_string_body() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/echo', {{
+                    method: 'POST',
+                    body: 'hello from test'
+                }});
+                return await resp.text();
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        assert_eq!(result.as_str().unwrap(), "hello from test");
+    }
+
+    // --- POST with JSON body ---
+
+    #[tokio::test]
+    async fn test_fetch_post_json_body() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/echo', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify({{ foo: 'bar' }})
+                }});
+                const text = await resp.text();
+                const parsed = JSON.parse(text);
+                return parsed.foo;
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        assert_eq!(result.as_str().unwrap(), "bar");
+    }
+
+    // --- Custom headers ---
+
+    #[tokio::test]
+    async fn test_fetch_custom_headers() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/echo', {{
+                    method: 'POST',
+                    headers: {{ 'x-custom': 'my-value' }},
+                    body: 'test'
+                }});
+                return resp.headers.get('x-echo-custom');
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        assert_eq!(result.as_str().unwrap(), "my-value");
+    }
+
+    // --- Non-200 status codes ---
+
+    #[tokio::test]
+    async fn test_fetch_404_status() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/not-found');
+                return [resp.status, resp.statusText];
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_u64().unwrap(), 404);
+        assert_eq!(arr[1].as_str().unwrap(), "Not Found");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_500_status() {
+        let (base_url, _handle) = start_test_server(simple_app()).await;
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            &format!(
+                r#"
+                const resp = await fetch('{}/server-error');
+                return [resp.status, resp.statusText, await resp.text()];
+            "#,
+                base_url
+            ),
+        )
+        .await;
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr[0].as_u64().unwrap(), 500);
+        assert_eq!(arr[1].as_str().unwrap(), "Internal Server Error");
+        assert_eq!(arr[2].as_str().unwrap(), "Internal Error");
+    }
+
+    // --- Error: network failure ---
+
+    #[tokio::test]
+    async fn test_fetch_network_failure() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await fetch('http://127.0.0.1:1/unreachable');
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('Fetch failed') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- Error: invalid HTTP method ---
+
+    #[tokio::test]
+    async fn test_fetch_invalid_method() {
+        let mut rt = create_runtime();
+        let result = run_async(
+            &mut rt,
+            r#"
+            try {
+                await fetch('http://127.0.0.1:1', { method: 'INVALID METHOD' });
+                return 'no-throw';
+            } catch (e) {
+                return e.message.includes('Invalid HTTP method') ? 'correct-error' : e.message;
+            }
+        "#,
+        )
+        .await;
+        assert_eq!(result, serde_json::json!("correct-error"));
+    }
+
+    // --- op_decls ---
+
+    #[test]
+    fn test_op_decls_returns_fetch_op() {
+        let decls = op_decls();
+        assert_eq!(decls.len(), 1);
+    }
+
+    // --- FETCH_BOOTSTRAP_JS ---
+
+    #[test]
+    fn test_fetch_bootstrap_js_is_non_empty() {
+        assert!(!FETCH_BOOTSTRAP_JS.is_empty());
+        assert!(FETCH_BOOTSTRAP_JS.contains("globalThis"));
+    }
+}


### PR DESCRIPTION
## Summary

- **fetch.rs**: 4.5% → 95%+ coverage with 11 new tests covering GET/POST requests, headers, body parsing (string and JSON), status codes (200/404/500), error handling (network failure, invalid HTTP method), `op_decls()`, and `FETCH_BOOTSTRAP_JS`
- **crypto_subtle.rs**: 56.2% → 95%+ coverage with 67 new tests (82 total) covering all uncovered branches: SHA-1/SHA-384 digest, HMAC/AES-GCM/HKDF/ECDSA/RSA import/export errors, P-384 ECDSA, RSA sign/verify with SHA-256/384/512, AES-128-GCM, AES-GCM with AAD, deriveKey→HMAC, and all error/validation paths

Fixes #13

## Test plan

- [x] All 82 crypto_subtle tests pass
- [x] All 11 fetch tests pass
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)