### PR TITLE
fix(ci): decouple GitHub release from npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,12 +146,12 @@ jobs:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Create GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(cat version.txt)
+          TAG="v${VERSION}"
           ASSETS=()
           for dir in npm/runtime-*/; do
             if [ -f "${dir}vtz" ]; then
@@ -162,7 +162,19 @@ jobs:
             fi
           done
 
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
+          if [ ${#ASSETS[@]} -eq 0 ]; then
+            echo "No binaries found, skipping release"
+            exit 0
+          fi
+
+          # Delete existing release for this version so we can recreate with fresh binaries
+          if gh release view "$TAG" &>/dev/null; then
+            echo "Release $TAG exists, updating with new binaries..."
+            gh release delete "$TAG" --yes
+            git push origin --delete "$TAG" 2>/dev/null || true
+          fi
+
+          gh release create "$TAG" \
+            --title "$TAG" \
             --generate-notes \
-            "${ASSETS[@]}" || true
+            "${ASSETS[@]}"


### PR DESCRIPTION
## Summary

- Removed the `if: steps.changesets.outputs.published == 'true'` gate on the GitHub release step
- GitHub releases with binaries are now created on every push to main, regardless of npm changesets state
- Added idempotency: if a release for the current version already exists, it's replaced with fresh binaries
- Added a guard to skip release creation if no binaries were built

**Root cause:** `curl -fsSL .../install.sh | sh` was returning 404 because GitHub releases were only created when changesets published npm packages — which had never happened yet.

## Test plan

- [ ] Merge to main and verify the Release workflow creates a GitHub release with binaries
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/vertz-dev/vtz/main/install.sh | sh` and confirm it installs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)