### PR TITLE
feat(compiler): tsconfig path alias resolution in imports

### DIFF
--- a/native/vtz/src/compiler/import_rewriter.rs
+++ b/native/vtz/src/compiler/import_rewriter.rs
@@ -1,15 +1,23 @@
 use std::path::{Path, PathBuf};
 
 use crate::deps::resolve;
+use crate::tsconfig::TsconfigPaths;
 
 /// Rewrite import specifiers in compiled JavaScript for browser consumption.
 ///
 /// Transforms:
 /// - Bare specifiers (`@vertz/ui`, `zod`) → `/@deps/@vertz/ui`, `/@deps/zod`
+/// - Path aliases (`@/components/Button`) → resolved file path via tsconfig paths
 /// - Relative specifiers (`./Foo`, `../utils/format`) → absolute paths with extensions
 /// - Already-absolute URLs (`http://`, `https://`) → unchanged
 /// - Already-rewritten paths (`/@deps/`, `/@css/`) → unchanged
-pub fn rewrite_imports(code: &str, file_path: &Path, src_dir: &Path, root_dir: &Path) -> String {
+pub fn rewrite_imports(
+    code: &str,
+    file_path: &Path,
+    src_dir: &Path,
+    root_dir: &Path,
+    tsconfig_paths: Option<&TsconfigPaths>,
+) -> String {
     let mut result = String::with_capacity(code.len() + 256);
     let chars: Vec<char> = code.chars().collect();
     let len = chars.len();
@@ -36,6 +44,7 @@ pub fn rewrite_imports(code: &str, file_path: &Path, src_dir: &Path, root_dir: &
                     file_path,
                     src_dir,
                     root_dir,
+                    tsconfig_paths,
                     &mut result,
                 );
                 continue;
@@ -52,6 +61,7 @@ pub fn rewrite_imports(code: &str, file_path: &Path, src_dir: &Path, root_dir: &
                     file_path,
                     src_dir,
                     root_dir,
+                    tsconfig_paths,
                     &mut result,
                 );
                 continue;
@@ -70,6 +80,7 @@ pub fn rewrite_imports(code: &str, file_path: &Path, src_dir: &Path, root_dir: &
                         file_path,
                         src_dir,
                         root_dir,
+                        tsconfig_paths,
                         &mut result,
                     );
                     continue;
@@ -98,6 +109,7 @@ pub fn rewrite_imports(code: &str, file_path: &Path, src_dir: &Path, root_dir: &
                         file_path,
                         src_dir,
                         root_dir,
+                        tsconfig_paths,
                         &mut result,
                     );
                     continue;
@@ -212,6 +224,9 @@ fn find_from_keyword(chars: &[char], start: usize, len: usize) -> Option<usize> 
 /// Rewrite a string-quoted specifier at position `pos`.
 /// `pos` points to the opening quote character.
 /// Returns the new position after the closing quote.
+// All parameters are needed: chars+pos+len for parsing, file_path+src_dir+root_dir+tsconfig_paths
+// for resolution, result for output.
+#[allow(clippy::too_many_arguments)]
 fn rewrite_string_specifier(
     chars: &[char],
     pos: usize,
@@ -219,6 +234,7 @@ fn rewrite_string_specifier(
     file_path: &Path,
     src_dir: &Path,
     root_dir: &Path,
+    tsconfig_paths: Option<&TsconfigPaths>,
     result: &mut String,
 ) -> usize {
     if pos >= len {
@@ -241,7 +257,7 @@ fn rewrite_string_specifier(
     }
 
     let specifier: String = chars[pos + 1..end].iter().collect();
-    let rewritten = rewrite_specifier(&specifier, file_path, src_dir, root_dir);
+    let rewritten = rewrite_specifier(&specifier, file_path, src_dir, root_dir, tsconfig_paths);
 
     result.push(quote);
     result.push_str(&rewritten);
@@ -258,6 +274,7 @@ pub fn rewrite_specifier(
     file_path: &Path,
     src_dir: &Path,
     root_dir: &Path,
+    tsconfig_paths: Option<&TsconfigPaths>,
 ) -> String {
     // Already-absolute URLs — don't touch
     if specifier.starts_with("http://")
@@ -276,6 +293,19 @@ pub fn rewrite_specifier(
     // Relative specifiers: ./foo, ../bar
     if specifier.starts_with("./") || specifier.starts_with("../") {
         return resolve_relative_specifier(specifier, file_path, src_dir, root_dir);
+    }
+
+    // Path aliases: resolve via tsconfig.json compilerOptions.paths
+    // This must happen before bare specifier handling so that aliases like
+    // `@/components/Button` don't get routed to `/@deps/@/components/Button`.
+    if let Some(paths) = tsconfig_paths {
+        if let Some(resolved) = paths.resolve_alias(specifier, root_dir) {
+            // Convert resolved absolute path to a URL path relative to root_dir
+            if let Ok(rel) = resolved.strip_prefix(root_dir) {
+                let rel_str = rel.to_string_lossy().replace('\\', "/");
+                return format!("/{}", rel_str);
+            }
+        }
     }
 
     // Bare specifiers: resolve via package.json exports to get full file path,
@@ -382,6 +412,7 @@ mod tests {
             Path::new("/project/src/app.tsx"),
             Path::new("/project/src"),
             Path::new("/project"),
+            None,
         );
         assert_eq!(result, "/@deps/@vertz/ui");
     }
@@ -393,6 +424,7 @@ mod tests {
             Path::new("/project/src/app.tsx"),
             Path::new("/project/src"),
             Path::new("/project"),
+            None,
         );
         assert_eq!(result, "/@deps/zod");
     }
@@ -404,6 +436,7 @@ mod tests {
             Path::new("/project/src/app.tsx"),
             Path::new("/project/src"),
             Path::new("/project"),
+            None,
         );
         assert_eq!(result, "/@deps/@vertz/ui/components");
     }
@@ -415,6 +448,7 @@ mod tests {
             Path::new("/project/src/app.tsx"),
             Path::new("/project/src"),
             Path::new("/project"),
+            None,
         );
         assert_eq!(result, "https://cdn.example.com/lib.js");
     }
@@ -426,6 +460,7 @@ mod tests {
             Path::new("/project/src/app.tsx"),
             Path::new("/project/src"),
             Path::new("/project"),
+            None,
         );
         assert_eq!(result, "/@deps/@vertz/ui");
     }
@@ -437,6 +472,7 @@ mod tests {
             Path::new("/project/src/app.tsx"),
             Path::new("/project/src"),
             Path::new("/project"),
+            None,
         );
         assert_eq!(result, "/@css/button.css");
     }
@@ -453,6 +489,7 @@ mod tests {
             &src_dir.join("app.tsx"),
             &src_dir,
             tmp.path(),
+            None,
         );
         assert_eq!(result, "/src/components/Button.tsx");
     }
@@ -470,6 +507,7 @@ mod tests {
             &src_dir.join("components/Button.tsx"),
             &src_dir,
             tmp.path(),
+            None,
         );
         assert_eq!(result, "/src/utils/format.ts");
     }
@@ -484,7 +522,7 @@ mod tests {
 import { z } from 'zod';
 const x = 1;"#;
 
-        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path());
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
 
         assert!(
             result.contains("from '/@deps/@vertz/ui'"),
@@ -502,7 +540,7 @@ const x = 1;"#;
 
         let code = r#"const mod = import('@vertz/ui');"#;
 
-        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path());
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
 
         assert!(
             result.contains("import('/@deps/@vertz/ui')"),
@@ -519,7 +557,7 @@ const x = 1;"#;
 
         let code = r#"export { signal } from '@vertz/ui';"#;
 
-        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path());
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
 
         assert!(
             result.contains("from '/@deps/@vertz/ui'"),
@@ -536,7 +574,7 @@ const x = 1;"#;
 
         let code = r#"import '@vertz/ui/styles';"#;
 
-        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path());
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
 
         assert!(
             result.contains("import '/@deps/@vertz/ui/styles'"),
@@ -555,7 +593,7 @@ const x = 1;"#;
 function foo() { return x + 2; }
 export default foo;"#;
 
-        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path());
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
 
         assert_eq!(result, code);
     }
@@ -578,6 +616,7 @@ export default foo;"#;
             &src_dir.join("app.tsx"),
             &src_dir,
             tmp.path(),
+            None,
         );
         assert_eq!(result, "/src/styles.css");
     }
@@ -593,7 +632,7 @@ export default foo;"#;
 import { signal } from '@vertz/ui';
 const x = 1;"#;
 
-        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path());
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, tmp.path(), None);
 
         assert!(
             result.contains("import '/src/App.css'"),
@@ -611,5 +650,101 @@ const x = 1;"#;
     fn test_normalize_path_with_dot() {
         let p = normalize_path(Path::new("/project/src/./utils/format"));
         assert_eq!(p, PathBuf::from("/project/src/utils/format"));
+    }
+
+    // ── Path alias tests ──
+
+    #[test]
+    fn test_rewrite_path_alias_to_resolved_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let src_dir = root.join("src");
+        std::fs::create_dir_all(src_dir.join("components")).unwrap();
+        std::fs::write(src_dir.join("components/Button.tsx"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        let result = rewrite_specifier(
+            "@/components/Button",
+            &src_dir.join("app.tsx"),
+            &src_dir,
+            root,
+            Some(&paths),
+        );
+        assert_eq!(result, "/src/components/Button.tsx");
+    }
+
+    #[test]
+    fn test_rewrite_alias_falls_through_to_bare_specifier() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let src_dir = root.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        // "react" doesn't match @/* so it falls through to bare specifier handling
+        let result = rewrite_specifier(
+            "react",
+            &src_dir.join("app.tsx"),
+            &src_dir,
+            root,
+            Some(&paths),
+        );
+        assert_eq!(result, "/@deps/react");
+    }
+
+    #[test]
+    fn test_rewrite_imports_with_path_alias() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let src_dir = root.join("src");
+        std::fs::create_dir_all(src_dir.join("components")).unwrap();
+        std::fs::write(src_dir.join("components/Button.tsx"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        let code = "import Button from '@/components/Button';";
+        let result = rewrite_imports(code, &src_dir.join("app.tsx"), &src_dir, root, Some(&paths));
+
+        assert!(
+            result.contains("from '/src/components/Button.tsx'"),
+            "Result: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_rewrite_alias_unresolved_file_falls_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let src_dir = root.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        // @/nonexistent matches the alias pattern, but no file exists.
+        // Falls through to bare specifier handling.
+        let result = rewrite_specifier(
+            "@/nonexistent",
+            &src_dir.join("app.tsx"),
+            &src_dir,
+            root,
+            Some(&paths),
+        );
+        // When alias matches but file not found, falls through to /@deps/
+        assert_eq!(result, "/@deps/@/nonexistent");
     }
 }

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -6,6 +6,7 @@ use std::time::SystemTime;
 use crate::compiler::cache::{CachedModule, CompilationCache};
 use crate::compiler::import_rewriter;
 use crate::plugin::{CompileContext, FrameworkPlugin};
+use crate::tsconfig::TsconfigPaths;
 
 /// A structured compilation error with source location.
 #[derive(Debug, Clone)]
@@ -46,6 +47,7 @@ pub struct CompilationPipeline {
     root_dir: PathBuf,
     src_dir: PathBuf,
     plugin: Arc<dyn FrameworkPlugin>,
+    tsconfig_paths: Option<TsconfigPaths>,
 }
 
 impl CompilationPipeline {
@@ -56,7 +58,16 @@ impl CompilationPipeline {
             root_dir,
             src_dir,
             plugin,
+            tsconfig_paths: None,
         }
+    }
+
+    /// Set the tsconfig path aliases for import resolution.
+    pub fn with_tsconfig_paths(mut self, paths: TsconfigPaths) -> Self {
+        if !paths.is_empty() {
+            self.tsconfig_paths = Some(paths);
+        }
+        self
     }
 
     /// Get the shared CSS store.
@@ -114,8 +125,13 @@ impl CompilationPipeline {
         let processed = self.plugin.post_process(&output.code, &ctx);
 
         // Rewrite import specifiers for browser consumption
-        let code =
-            import_rewriter::rewrite_imports(&processed, file_path, &self.src_dir, &self.root_dir);
+        let code = import_rewriter::rewrite_imports(
+            &processed,
+            file_path,
+            &self.src_dir,
+            &self.root_dir,
+            self.tsconfig_paths.as_ref(),
+        );
 
         // Handle extracted CSS
         let css = output.css;

--- a/native/vtz/src/hmr/recovery.rs
+++ b/native/vtz/src/hmr/recovery.rs
@@ -111,6 +111,8 @@ impl Default for RestartTriggers {
                 ".env".to_string(),
                 ".env.local".to_string(),
                 ".env.development".to_string(),
+                "tsconfig.json".to_string(),
+                "tsconfig.app.json".to_string(),
             ],
         }
     }
@@ -216,7 +218,14 @@ mod tests {
 
         assert!(!triggers.is_restart_trigger(Path::new("/project/src/app.tsx")));
         assert!(!triggers.is_restart_trigger(Path::new("/project/src/utils.ts")));
-        assert!(!triggers.is_restart_trigger(Path::new("/project/tsconfig.json")));
+    }
+
+    #[test]
+    fn test_tsconfig_triggers_restart() {
+        let triggers = RestartTriggers::default();
+
+        assert!(triggers.is_restart_trigger(Path::new("/project/tsconfig.json")));
+        assert!(triggers.is_restart_trigger(Path::new("/project/tsconfig.app.json")));
     }
 
     #[test]

--- a/native/vtz/src/lib.rs
+++ b/native/vtz/src/lib.rs
@@ -11,5 +11,6 @@ pub mod runtime;
 pub mod server;
 pub mod ssr;
 pub mod test;
+pub mod tsconfig;
 pub mod typecheck;
 pub mod watcher;

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -17,6 +17,7 @@ use crate::server::mcp::{self, McpSessions};
 use crate::server::mcp_events::{self, McpEventHub};
 use crate::server::module_server::{self, DevServerState};
 use crate::server::theme_css;
+use crate::tsconfig;
 use crate::typecheck::process;
 use crate::watcher;
 use crate::watcher::dep_watcher::{DepWatcher, DepWatcherConfig};
@@ -95,11 +96,26 @@ pub fn build_router(
     config: &ServerConfig,
     plugin: Arc<dyn crate::plugin::FrameworkPlugin>,
 ) -> (Router, Arc<DevServerState>) {
+    // Parse tsconfig.json path aliases for import resolution
+    let tsconfig_path = config
+        .tsconfig_path
+        .clone()
+        .unwrap_or_else(|| config.root_dir.join("tsconfig.json"));
+    let tsconfig_paths = tsconfig::parse_tsconfig_paths(&tsconfig_path);
+    if !tsconfig_paths.is_empty() {
+        eprintln!(
+            "[config] Loaded {} path alias(es) from {}",
+            tsconfig_paths.paths.len(),
+            tsconfig_path.display()
+        );
+    }
+
     let pipeline = CompilationPipeline::new(
         config.root_dir.clone(),
         config.src_dir.clone(),
         plugin.clone(),
-    );
+    )
+    .with_tsconfig_paths(tsconfig_paths);
 
     // Load theme CSS from the project (if available)
     let theme_css = theme_css::load_theme_css(&config.root_dir);

--- a/native/vtz/src/server/module_server.rs
+++ b/native/vtz/src/server/module_server.rs
@@ -667,8 +667,9 @@ fn serve_js_file(path: &Path, root_dir: &Path) -> Response<Body> {
             // node_modules layout where transitive deps live next to the package.
             let real_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
             // Rewrite bare specifiers in the file (e.g., `@vertz/errors` → `/@deps/@vertz/errors/dist/index.js`)
+            // No tsconfig path aliases for node_modules files
             let rewritten = crate::compiler::import_rewriter::rewrite_imports(
-                &content, &real_path, &real_path, root_dir,
+                &content, &real_path, &real_path, root_dir, None,
             );
             Response::builder()
                 .status(StatusCode::OK)

--- a/native/vtz/src/tsconfig.rs
+++ b/native/vtz/src/tsconfig.rs
@@ -1,0 +1,487 @@
+use std::path::{Path, PathBuf};
+
+/// Resolved path alias mappings from tsconfig.json `compilerOptions.paths`.
+#[derive(Debug, Clone, Default)]
+pub struct TsconfigPaths {
+    /// Base URL for non-relative module lookups (absolute, resolved from tsconfig location).
+    pub base_url: Option<PathBuf>,
+    /// Path alias mappings: (pattern, list of replacement patterns).
+    /// Patterns may contain a single `*` wildcard.
+    pub paths: Vec<(String, Vec<String>)>,
+}
+
+impl TsconfigPaths {
+    /// Returns true if there are no path aliases configured.
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+
+    /// Resolve a specifier against the configured path aliases.
+    ///
+    /// Returns the resolved file path if the specifier matches an alias and
+    /// a matching file exists on disk. Tries each mapping in order (first match wins).
+    /// Returns `None` if no alias matches or no file exists for any mapping.
+    pub fn resolve_alias(&self, specifier: &str, root_dir: &Path) -> Option<PathBuf> {
+        for (pattern, targets) in &self.paths {
+            if let Some(captured) = match_alias_pattern(pattern, specifier) {
+                for target in targets {
+                    let resolved = substitute_wildcard(target, captured);
+                    let base = self.base_url.as_deref().unwrap_or(root_dir);
+                    let full_path = base.join(&resolved);
+                    if let Some(found) = resolve_with_extensions(&full_path) {
+                        return Some(found);
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Match a specifier against an alias pattern.
+///
+/// For wildcard patterns (e.g., `@/*`), returns the captured portion after the prefix.
+/// For exact patterns, returns an empty string on match.
+/// Returns `None` if the specifier doesn't match.
+fn match_alias_pattern<'a>(pattern: &str, specifier: &'a str) -> Option<&'a str> {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        // Wildcard pattern: @/* matches @/anything
+        specifier.strip_prefix(prefix)
+    } else {
+        // Exact match
+        if specifier == pattern {
+            Some("")
+        } else {
+            None
+        }
+    }
+}
+
+/// Substitute the wildcard capture into a target pattern.
+///
+/// For `./src/*` with capture `components/Button`, returns `./src/components/Button`.
+/// For targets without `*`, returns the target as-is.
+fn substitute_wildcard(target: &str, capture: &str) -> String {
+    if let Some(prefix) = target.strip_suffix('*') {
+        format!("{}{}", prefix, capture)
+    } else {
+        target.to_string()
+    }
+}
+
+/// Try to resolve a path by adding extensions or finding index files.
+fn resolve_with_extensions(path: &Path) -> Option<PathBuf> {
+    // If path already has a known extension and exists
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        if matches!(ext, "ts" | "tsx" | "js" | "jsx" | "mjs" | "css") && path.exists() {
+            return Some(path.to_path_buf());
+        }
+    }
+
+    // Try common extensions
+    let extensions = [".tsx", ".ts", ".jsx", ".js", ".mjs"];
+    for ext in &extensions {
+        let with_ext = PathBuf::from(format!("{}{}", path.display(), ext));
+        if with_ext.exists() {
+            return Some(with_ext);
+        }
+    }
+
+    // Try as directory with index files
+    if path.is_dir() {
+        let index_files = ["index.tsx", "index.ts", "index.jsx", "index.js"];
+        for index in &index_files {
+            let index_path = path.join(index);
+            if index_path.exists() {
+                return Some(index_path);
+            }
+        }
+    }
+
+    None
+}
+
+/// Parse tsconfig.json at the given path and extract path alias configuration.
+///
+/// Follows the `extends` chain to inherit paths from base configs.
+/// Returns `TsconfigPaths` with resolved base_url and path mappings.
+pub fn parse_tsconfig_paths(tsconfig_path: &Path) -> TsconfigPaths {
+    let content = match std::fs::read_to_string(tsconfig_path) {
+        Ok(c) => c,
+        Err(_) => return TsconfigPaths::default(),
+    };
+
+    let json: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return TsconfigPaths::default(),
+    };
+
+    let tsconfig_dir = tsconfig_path.parent().unwrap_or(Path::new("."));
+
+    // Follow `extends` chain first to get base config
+    let mut result = if let Some(extends) = json.get("extends").and_then(|v| v.as_str()) {
+        let base_path = tsconfig_dir.join(extends);
+        // If extends doesn't end in .json, try appending it
+        let base_path = if base_path.extension().is_none() {
+            base_path.with_extension("json")
+        } else {
+            base_path
+        };
+        parse_tsconfig_paths(&base_path)
+    } else {
+        TsconfigPaths::default()
+    };
+
+    let compiler_options = match json.get("compilerOptions") {
+        Some(co) => co,
+        None => return result,
+    };
+
+    // Parse baseUrl (resolved relative to tsconfig location)
+    if let Some(base_url) = compiler_options.get("baseUrl").and_then(|v| v.as_str()) {
+        result.base_url = Some(tsconfig_dir.join(base_url));
+    }
+
+    // Parse paths — these override any inherited paths
+    if let Some(paths_obj) = compiler_options.get("paths").and_then(|v| v.as_object()) {
+        let mut paths = Vec::new();
+        for (pattern, targets) in paths_obj {
+            if let Some(arr) = targets.as_array() {
+                let target_strings: Vec<String> = arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                if !target_strings.is_empty() {
+                    paths.push((pattern.clone(), target_strings));
+                }
+            }
+        }
+        result.paths = paths;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_paths() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tsconfig = tmp.path().join("tsconfig.json");
+        std::fs::write(
+            &tsconfig,
+            r#"{
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["./src/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_tsconfig_paths(&tsconfig);
+
+        assert_eq!(result.paths.len(), 1);
+        assert_eq!(result.paths[0].0, "@/*");
+        assert_eq!(result.paths[0].1, vec!["./src/*"]);
+    }
+
+    #[test]
+    fn test_parse_base_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tsconfig = tmp.path().join("tsconfig.json");
+        std::fs::write(
+            &tsconfig,
+            r#"{
+                "compilerOptions": {
+                    "baseUrl": ".",
+                    "paths": {
+                        "@/*": ["./src/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_tsconfig_paths(&tsconfig);
+
+        assert_eq!(result.base_url, Some(tmp.path().join(".")));
+    }
+
+    #[test]
+    fn test_parse_multiple_aliases() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tsconfig = tmp.path().join("tsconfig.json");
+        std::fs::write(
+            &tsconfig,
+            r#"{
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["./src/*"],
+                        "@components/*": ["./src/components/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_tsconfig_paths(&tsconfig);
+
+        assert_eq!(result.paths.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_multiple_mappings_per_alias() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tsconfig = tmp.path().join("tsconfig.json");
+        std::fs::write(
+            &tsconfig,
+            r#"{
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["./src/*", "./generated/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_tsconfig_paths(&tsconfig);
+
+        assert_eq!(result.paths[0].1, vec!["./src/*", "./generated/*"]);
+    }
+
+    #[test]
+    fn test_parse_extends_inherits_base_url() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Base config
+        let base = tmp.path().join("tsconfig.base.json");
+        std::fs::write(
+            &base,
+            r#"{
+                "compilerOptions": {
+                    "baseUrl": "."
+                }
+            }"#,
+        )
+        .unwrap();
+
+        // App config extends base and adds paths
+        let app = tmp.path().join("tsconfig.json");
+        std::fs::write(
+            &app,
+            r#"{
+                "extends": "./tsconfig.base.json",
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["./src/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_tsconfig_paths(&app);
+
+        // baseUrl inherited from base config
+        assert_eq!(result.base_url, Some(tmp.path().join(".")));
+        // paths from app config
+        assert_eq!(result.paths.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_extends_child_paths_override_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let base = tmp.path().join("tsconfig.base.json");
+        std::fs::write(
+            &base,
+            r#"{
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["./lib/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let app = tmp.path().join("tsconfig.json");
+        std::fs::write(
+            &app,
+            r#"{
+                "extends": "./tsconfig.base.json",
+                "compilerOptions": {
+                    "paths": {
+                        "@/*": ["./src/*"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let result = parse_tsconfig_paths(&app);
+
+        // Child paths override parent
+        assert_eq!(result.paths[0].1, vec!["./src/*"]);
+    }
+
+    #[test]
+    fn test_parse_missing_file_returns_empty() {
+        let result = parse_tsconfig_paths(Path::new("/nonexistent/tsconfig.json"));
+
+        assert!(result.is_empty());
+        assert!(result.base_url.is_none());
+    }
+
+    #[test]
+    fn test_parse_invalid_json_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tsconfig = tmp.path().join("tsconfig.json");
+        std::fs::write(&tsconfig, "not valid json").unwrap();
+
+        let result = parse_tsconfig_paths(&tsconfig);
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_no_compiler_options_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tsconfig = tmp.path().join("tsconfig.json");
+        std::fs::write(&tsconfig, r#"{"include": ["src"]}"#).unwrap();
+
+        let result = parse_tsconfig_paths(&tsconfig);
+
+        assert!(result.is_empty());
+    }
+
+    // ── resolve_alias tests ──
+
+    #[test]
+    fn test_resolve_alias_wildcard_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src/components")).unwrap();
+        std::fs::write(root.join("src/components/Button.tsx"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        let result = paths.resolve_alias("@/components/Button", root);
+        assert_eq!(result, Some(root.join("src/components/Button.tsx")));
+    }
+
+    #[test]
+    fn test_resolve_alias_no_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        let result = paths.resolve_alias("react", tmp.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_resolve_alias_multiple_mappings_first_match_wins() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        // Only the second mapping has the file
+        std::fs::create_dir_all(root.join("generated/models")).unwrap();
+        std::fs::write(root.join("generated/models/User.ts"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![(
+                "@/*".to_string(),
+                vec!["./src/*".to_string(), "./generated/*".to_string()],
+            )],
+        };
+
+        let result = paths.resolve_alias("@/models/User", root);
+        assert_eq!(result, Some(root.join("generated/models/User.ts")));
+    }
+
+    #[test]
+    fn test_resolve_alias_exact_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/config.ts"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@config".to_string(), vec!["./src/config".to_string()])],
+        };
+
+        let result = paths.resolve_alias("@config", root);
+        assert_eq!(result, Some(root.join("src/config.ts")));
+    }
+
+    #[test]
+    fn test_resolve_alias_with_base_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src/utils")).unwrap();
+        std::fs::write(root.join("src/utils/helpers.ts"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: Some(root.join("src")),
+            paths: vec![("@utils/*".to_string(), vec!["utils/*".to_string()])],
+        };
+
+        let result = paths.resolve_alias("@utils/helpers", root);
+        assert_eq!(result, Some(root.join("src/utils/helpers.ts")));
+    }
+
+    #[test]
+    fn test_resolve_alias_index_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src/components/Button")).unwrap();
+        std::fs::write(root.join("src/components/Button/index.tsx"), "").unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        let result = paths.resolve_alias("@/components/Button", root);
+        assert_eq!(result, Some(root.join("src/components/Button/index.tsx")));
+    }
+
+    #[test]
+    fn test_resolve_alias_file_not_found_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+
+        let result = paths.resolve_alias("@/nonexistent/Thing", root);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let paths = TsconfigPaths::default();
+        assert!(paths.is_empty());
+
+        let paths = TsconfigPaths {
+            base_url: None,
+            paths: vec![("@/*".to_string(), vec!["./src/*".to_string()])],
+        };
+        assert!(!paths.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- **New `tsconfig` module** (`native/vtz/src/tsconfig.rs`) — parses `compilerOptions.paths` and `baseUrl` from `tsconfig.json`, follows `extends` chain
- **Import rewriter** now resolves path aliases before bare specifier handling, so `@/components/Button` → `/src/components/Button.tsx` instead of `/@deps/@/components/Button`
- **Restart triggers** — `tsconfig.json` and `tsconfig.app.json` changes now trigger a full server restart
- **Pipeline integration** — tsconfig paths parsed at startup and passed through to the import rewriter

Closes #40

## Public API Changes

None — this is an internal compiler behavior change. Existing imports continue to work as before.

## Test plan

- [x] 10 tests for tsconfig parsing (simple paths, baseUrl, extends inheritance, extends override, multiple aliases, multiple mappings, missing file, invalid JSON, no compilerOptions)
- [x] 7 tests for alias resolution (wildcard match, no match, multiple mappings first-match-wins, exact match, baseUrl resolution, index file resolution, file-not-found returns None)
- [x] 4 tests for import rewriter integration (alias → resolved URL, alias fallthrough to bare specifier, full `rewrite_imports` with alias, unresolved alias fallthrough)
- [x] 2 tests for restart triggers (tsconfig.json and tsconfig.app.json trigger restarts)
- [x] All 3,300+ existing tests continue to pass
- [x] clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)