### PR TITLE
Fix proxy dashboard links

### DIFF
--- a/native/vtz/src/proxy/client.rs
+++ b/native/vtz/src/proxy/client.rs
@@ -66,18 +66,11 @@ pub fn is_proxy_running() -> bool {
         .unwrap_or(false)
 }
 
-/// Register a dev server with the proxy.
-///
-/// Returns the subdomain if registration was successful, or `None` if proxy isn't running.
-pub fn register_dev_server(
+fn build_route_entry(
     root_dir: &Path,
     port: u16,
     name_override: Option<&str>,
-) -> Option<String> {
-    if !is_proxy_running() {
-        return None;
-    }
-
+) -> Option<RouteEntry> {
     // Detect branch and project once, reuse for both subdomain and entry
     let branch = detect_git_branch(root_dir).unwrap_or_else(|| "main".to_string());
     let project = detect_project_name(root_dir);
@@ -92,17 +85,31 @@ pub fn register_dev_server(
         return None;
     }
 
-    let entry = RouteEntry {
-        subdomain: subdomain.clone(),
+    Some(RouteEntry {
+        subdomain,
         port,
         branch,
         project,
         pid: std::process::id(),
         root_dir: root_dir.to_path_buf(),
-    };
+    })
+}
 
+/// Register a dev server with the proxy.
+///
+/// Returns the subdomain if registration was successful, or `None` if proxy isn't running.
+pub fn register_dev_server(
+    root_dir: &Path,
+    port: u16,
+    name_override: Option<&str>,
+) -> Option<String> {
+    if !is_proxy_running() {
+        return None;
+    }
+
+    let entry = build_route_entry(root_dir, port, name_override)?;
     routes::register(&entry).ok()?;
-    Some(subdomain)
+    Some(entry.subdomain)
 }
 
 /// Deregister a dev server from the proxy.
@@ -193,5 +200,29 @@ mod tests {
     fn detect_git_branch_returns_none_for_no_git() {
         let dir = tempfile::tempdir().unwrap();
         assert_eq!(detect_git_branch(dir.path()), None);
+    }
+
+    #[test]
+    fn build_route_entry_uses_sanitized_name_override() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"name": "my-awesome-app"}"#,
+        )
+        .unwrap();
+
+        let entry = build_route_entry(dir.path(), 3000, Some("Dashboard !!!")).unwrap();
+
+        assert_eq!(entry.subdomain, "dashboard");
+        assert_eq!(entry.project, "my-awesome-app");
+        assert_eq!(entry.branch, "main");
+        assert_eq!(entry.port, 3000);
+        assert_eq!(entry.root_dir, dir.path());
+    }
+
+    #[test]
+    fn build_route_entry_returns_none_when_name_sanitizes_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(build_route_entry(dir.path(), 3000, Some("!!!")).is_none());
     }
 }

--- a/native/vtz/src/proxy/daemon.rs
+++ b/native/vtz/src/proxy/daemon.rs
@@ -106,7 +106,7 @@ async fn proxy_handler(
 
     let subdomain = match extract_subdomain(host) {
         Some(s) => s,
-        None => return dashboard_response(&state).await,
+        None => return dashboard_response(&state, host).await,
     };
 
     // Periodically refresh the route table from disk
@@ -298,6 +298,17 @@ async fn convert_response(resp: reqwest::Response) -> Response<Body> {
     }
 }
 
+fn dashboard_link_href(subdomain: &str, host: &str) -> String {
+    let port = host
+        .rsplit_once(':')
+        .map(|(_, port)| port)
+        .filter(|port| !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()));
+    match port {
+        Some(port) => format!("//{subdomain}.localhost:{port}"),
+        None => format!("//{subdomain}.localhost"),
+    }
+}
+
 /// Escape HTML special characters to prevent XSS.
 fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
@@ -308,7 +319,7 @@ fn html_escape(s: &str) -> String {
 }
 
 /// Dashboard page listing all registered dev servers.
-async fn dashboard_response(state: &ProxyState) -> Response<Body> {
+async fn dashboard_response(state: &ProxyState, host: &str) -> Response<Body> {
     state.reload_routes().await;
     let table = state.route_table.read().await;
 
@@ -331,8 +342,9 @@ async fn dashboard_response(state: &ProxyState) -> Response<Body> {
     for entry in table.values() {
         let sub = html_escape(&entry.subdomain);
         let branch = html_escape(&entry.branch);
+        let href = html_escape(&dashboard_link_href(&entry.subdomain, host));
         rows.push_str(&format!(
-            "<tr><td><a href=\"http://{sub}.localhost\">{sub}</a></td>\
+            "<tr><td><a href=\"{href}\">{sub}</a></td>\
              <td>{port}</td><td>{branch}</td><td>{pid}</td></tr>",
             port = entry.port,
             pid = entry.pid,
@@ -576,7 +588,7 @@ mod tests {
         let routes = dir.path().join("routes");
         let state = ProxyState::new(routes);
 
-        let resp = dashboard_response(&state).await;
+        let resp = dashboard_response(&state, "localhost").await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
@@ -593,13 +605,14 @@ mod tests {
         routes::register_in(&routes, &entry).unwrap();
 
         let state = ProxyState::new(routes);
-        let resp = dashboard_response(&state).await;
+        let resp = dashboard_response(&state, "localhost:4000").await;
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
         let html = String::from_utf8(body.to_vec()).unwrap();
         assert!(html.contains("feat-test.test-app"));
         assert!(html.contains("3000"));
+        assert!(html.contains("href=\"//feat-test.test-app.localhost:4000\""));
     }
 
     #[tokio::test]
@@ -907,7 +920,7 @@ mod tests {
         routes::register_in(&routes, &entry).unwrap();
 
         let state = ProxyState::new(routes);
-        let resp = dashboard_response(&state).await;
+        let resp = dashboard_response(&state, "localhost").await;
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
             .await
             .unwrap();
@@ -915,5 +928,37 @@ mod tests {
         // The raw <script> tag should NOT appear in the HTML
         assert!(!html.contains("<script>"));
         assert!(html.contains("&lt;script&gt;"));
+    }
+
+    #[test]
+    fn dashboard_link_href_preserves_proxy_port() {
+        assert_eq!(
+            dashboard_link_href("feat-auth.my-app", "localhost:8443"),
+            "//feat-auth.my-app.localhost:8443"
+        );
+    }
+
+    #[test]
+    fn dashboard_link_href_omits_port_when_not_present() {
+        assert_eq!(
+            dashboard_link_href("feat-auth.my-app", "localhost"),
+            "//feat-auth.my-app.localhost"
+        );
+    }
+
+    #[test]
+    fn dashboard_link_href_ignores_non_numeric_port() {
+        assert_eq!(
+            dashboard_link_href("feat-auth.my-app", "localhost:notaport"),
+            "//feat-auth.my-app.localhost"
+        );
+    }
+
+    #[test]
+    fn dashboard_link_href_handles_empty_host() {
+        assert_eq!(
+            dashboard_link_href("feat-auth.my-app", ""),
+            "//feat-auth.my-app.localhost"
+        );
     }
 }


### PR DESCRIPTION
This updates the built-in proxy dashboard to generate subdomain links from the active host, so links preserve the proxy port instead of hardcoding plain localhost URLs. It also refactors proxy route entry construction into a helper so the  path is directly testable and adds coverage for name sanitization and dashboard link generation. Verified with .

closes #44 