### PR TITLE
chore: add changeset for 0.0.3 release

### DIFF
--- a/.changeset/release-0.0.3.md
+++ b/.changeset/release-0.0.3.md
@@ -1,0 +1,12 @@
+---
+"@vertz/runtime": patch
+---
+
+### New Features
+- **Plugin API** — `FrameworkPlugin` trait with React plugin (TSX compilation, HMR, React Refresh)
+- **CSS file imports** — `import './styles.css'` injects styles in dev server
+- **PostCSS pipeline** — CSS imports processed through PostCSS when configured
+- **Asset imports** — `import logo from './logo.png'` resolves to URL strings
+- **`import.meta.env`** — `.env` file loading with `VERTZ_` prefix filtering
+- **tsconfig path aliases** — `paths` from `tsconfig.json` resolved in import rewriter
+- **Reverse proxy** — subdomain routing, WebSocket proxying, TLS/HTTPS with auto-generated certs, `/etc/hosts` sync, loop detection


### PR DESCRIPTION
Adds a changeset for the 0.0.3 patch release, summarizing all features added since 0.0.2: plugin API, CSS/PostCSS imports, asset imports, `import.meta.env`, tsconfig path aliases, and reverse proxy with TLS/WebSocket support.