### PR TITLE
refactor(pipeline): extract PostCSS into CSS transform hook

### DIFF
--- a/native/vtz/src/compiler/css_transform.rs
+++ b/native/vtz/src/compiler/css_transform.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+use crate::compiler::pipeline::CompileError;
+
+/// A CSS transform hook for the compilation pipeline.
+///
+/// Implementations process CSS files (e.g., PostCSS, Lightning CSS, Tailwind v4).
+/// The pipeline delegates to registered transforms instead of hardcoding tool-specific logic.
+pub trait CssTransform: Send + Sync {
+    /// Process a CSS file and return the transformed CSS.
+    ///
+    /// `file_path` is the path to the CSS file on disk.
+    /// `root_dir` is the project root (for resolving configs, node_modules, etc.).
+    fn process(&self, file_path: &Path, root_dir: &Path) -> Result<String, Vec<CompileError>>;
+}

--- a/native/vtz/src/compiler/mod.rs
+++ b/native/vtz/src/compiler/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod css_transform;
 pub mod env_replacer;
 pub mod import_rewriter;
 pub mod pipeline;

--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -4,9 +4,9 @@ use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
 use crate::compiler::cache::{CachedModule, CompilationCache};
+use crate::compiler::css_transform::CssTransform;
 use crate::compiler::env_replacer;
 use crate::compiler::import_rewriter;
-use crate::compiler::postcss;
 use crate::plugin::{CompileContext, FrameworkPlugin};
 use crate::tsconfig::TsconfigPaths;
 
@@ -52,6 +52,8 @@ pub struct CompilationPipeline {
     tsconfig_paths: Option<TsconfigPaths>,
     /// Public env vars for `import.meta.env` compile-time replacement.
     env: HashMap<String, String>,
+    /// Optional CSS transform hook (e.g., PostCSS, Lightning CSS).
+    css_transform: Option<Arc<dyn CssTransform>>,
 }
 
 impl CompilationPipeline {
@@ -64,6 +66,7 @@ impl CompilationPipeline {
             plugin,
             tsconfig_paths: None,
             env: HashMap::new(),
+            css_transform: None,
         }
     }
 
@@ -78,6 +81,15 @@ impl CompilationPipeline {
     /// Set the public env vars for `import.meta.env` compile-time replacement.
     pub fn with_env(mut self, env: HashMap<String, String>) -> Self {
         self.env = env;
+        self
+    }
+
+    /// Set a CSS transform hook (e.g., PostCSS).
+    ///
+    /// When set, `compile_css_for_browser` delegates to this transform
+    /// instead of reading the raw CSS file.
+    pub fn with_css_transform(mut self, transform: Arc<dyn CssTransform>) -> Self {
+        self.css_transform = Some(transform);
         self
     }
 
@@ -205,27 +217,25 @@ impl CompilationPipeline {
             };
         }
 
-        // When PostCSS is configured the JS runner reads the file itself,
-        // so only read from Rust when falling back to raw CSS.
-        let processed_css = match postcss::find_postcss_config(&self.root_dir) {
-            Some(config_path) => {
-                match postcss::process_css(&self.root_dir, file_path, &config_path) {
-                    Ok(css) => css,
-                    Err(err) => {
-                        return BrowserCompileResult {
-                            code: self.css_error_module(&err.message),
-                            source_map: None,
-                            css: None,
-                            errors: vec![CompileError {
-                                message: err.message,
-                                line: err.line,
-                                column: err.column,
-                            }],
-                        };
-                    }
+        // Delegate to the CSS transform hook if registered, otherwise read raw CSS.
+        let processed_css = if let Some(ref transform) = self.css_transform {
+            match transform.process(file_path, &self.root_dir) {
+                Ok(css) => css,
+                Err(errors) => {
+                    let message = errors
+                        .first()
+                        .map(|e| e.message.as_str())
+                        .unwrap_or("CSS transform failed");
+                    return BrowserCompileResult {
+                        code: self.css_error_module(message),
+                        source_map: None,
+                        css: None,
+                        errors,
+                    };
                 }
             }
-            None => match std::fs::read_to_string(file_path) {
+        } else {
+            match std::fs::read_to_string(file_path) {
                 Ok(source) => source,
                 Err(err) => {
                     return self.error_module(&format!(
@@ -234,7 +244,7 @@ impl CompilationPipeline {
                         err
                     ));
                 }
-            },
+            }
         };
 
         let code = crate::server::css_server::css_to_js_module(&processed_css, url_path);
@@ -1384,6 +1394,8 @@ export function App() {
 
     #[test]
     fn test_compile_css_with_postcss_config_processes_css() {
+        use crate::compiler::postcss::{find_postcss_config, PostCssCssTransform};
+
         let tmp = tempfile::tempdir().unwrap();
         let src_dir = tmp.path().join("src");
         let node_modules = tmp.path().join("node_modules");
@@ -1432,7 +1444,9 @@ export function App() {
         )
         .unwrap();
 
-        let pipeline = create_pipeline(tmp.path());
+        let config_path = find_postcss_config(tmp.path()).expect("config should exist");
+        let transform = Arc::new(PostCssCssTransform::new(config_path));
+        let pipeline = create_pipeline(tmp.path()).with_css_transform(transform);
         let result = pipeline.compile_css_for_browser(&src_dir.join("app.css"), "/src/app.css");
 
         assert!(
@@ -1446,6 +1460,8 @@ export function App() {
 
     #[test]
     fn test_compile_css_with_postcss_error_returns_error_module() {
+        use crate::compiler::postcss::{find_postcss_config, PostCssCssTransform};
+
         let tmp = tempfile::tempdir().unwrap();
         let src_dir = tmp.path().join("src");
         let node_modules = tmp.path().join("node_modules");
@@ -1497,12 +1513,78 @@ export function App() {
         )
         .unwrap();
 
-        let pipeline = create_pipeline(tmp.path());
+        let config_path = find_postcss_config(tmp.path()).expect("config should exist");
+        let transform = Arc::new(PostCssCssTransform::new(config_path));
+        let pipeline = create_pipeline(tmp.path()).with_css_transform(transform);
         let result = pipeline.compile_css_for_browser(&src_dir.join("app.css"), "/src/app.css");
 
         assert_eq!(result.errors.len(), 1);
         assert_eq!(result.errors[0].line, Some(1));
         assert_eq!(result.errors[0].column, Some(1));
+        assert!(result.code.contains("CSS error"));
+        assert!(pipeline.cache().is_empty());
+    }
+
+    #[test]
+    fn test_compile_css_with_custom_transform() {
+        use crate::compiler::css_transform::CssTransform;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(src_dir.join("app.css"), "body { color: red; }\n").unwrap();
+
+        struct UpperCaseTransform;
+
+        impl CssTransform for UpperCaseTransform {
+            fn process(
+                &self,
+                file_path: &Path,
+                _root_dir: &Path,
+            ) -> Result<String, Vec<CompileError>> {
+                let source = std::fs::read_to_string(file_path).unwrap();
+                Ok(source.to_uppercase())
+            }
+        }
+
+        let pipeline = create_pipeline(tmp.path()).with_css_transform(Arc::new(UpperCaseTransform));
+        let result = pipeline.compile_css_for_browser(&src_dir.join("app.css"), "/src/app.css");
+
+        assert!(result.errors.is_empty());
+        assert!(result.code.contains("BODY { COLOR: RED; }"));
+    }
+
+    #[test]
+    fn test_compile_css_with_transform_error() {
+        use crate::compiler::css_transform::CssTransform;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let src_dir = tmp.path().join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::write(src_dir.join("app.css"), "@broken;\n").unwrap();
+
+        struct FailingTransform;
+
+        impl CssTransform for FailingTransform {
+            fn process(
+                &self,
+                _file_path: &Path,
+                _root_dir: &Path,
+            ) -> Result<String, Vec<CompileError>> {
+                Err(vec![CompileError {
+                    message: "Transform failed".to_string(),
+                    line: Some(1),
+                    column: Some(1),
+                }])
+            }
+        }
+
+        let pipeline = create_pipeline(tmp.path()).with_css_transform(Arc::new(FailingTransform));
+        let result = pipeline.compile_css_for_browser(&src_dir.join("app.css"), "/src/app.css");
+
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].message, "Transform failed");
+        assert_eq!(result.errors[0].line, Some(1));
         assert!(result.code.contains("CSS error"));
         assert!(pipeline.cache().is_empty());
     }

--- a/native/vtz/src/compiler/postcss.rs
+++ b/native/vtz/src/compiler/postcss.rs
@@ -158,6 +158,36 @@ struct RunnerError {
     column: Option<u32>,
 }
 
+/// A [`CssTransform`] implementation that processes CSS through PostCSS.
+///
+/// Created when a PostCSS config file is detected in the project root.
+/// Use [`find_postcss_config`] to detect config, then construct this transform.
+pub struct PostCssCssTransform {
+    config_path: PathBuf,
+}
+
+impl PostCssCssTransform {
+    pub fn new(config_path: PathBuf) -> Self {
+        Self { config_path }
+    }
+}
+
+impl crate::compiler::css_transform::CssTransform for PostCssCssTransform {
+    fn process(
+        &self,
+        file_path: &Path,
+        root_dir: &Path,
+    ) -> Result<String, Vec<crate::compiler::pipeline::CompileError>> {
+        process_css(root_dir, file_path, &self.config_path).map_err(|err| {
+            vec![crate::compiler::pipeline::CompileError {
+                message: err.message,
+                line: err.line,
+                column: err.column,
+            }]
+        })
+    }
+}
+
 pub fn find_postcss_config(root_dir: &Path) -> Option<PathBuf> {
     POSTCSS_CONFIG_FILES
         .iter()

--- a/native/vtz/src/server/http.rs
+++ b/native/vtz/src/server/http.rs
@@ -128,13 +128,24 @@ pub fn build_router(
         }
     }
 
-    let pipeline = CompilationPipeline::new(
+    let css_transform =
+        crate::compiler::postcss::find_postcss_config(&config.root_dir).map(|config_path| {
+            std::sync::Arc::new(crate::compiler::postcss::PostCssCssTransform::new(
+                config_path,
+            )) as std::sync::Arc<dyn crate::compiler::css_transform::CssTransform>
+        });
+
+    let mut pipeline = CompilationPipeline::new(
         config.root_dir.clone(),
         config.src_dir.clone(),
         plugin.clone(),
     )
     .with_tsconfig_paths(tsconfig_paths)
     .with_env(public_env);
+
+    if let Some(transform) = css_transform {
+        pipeline = pipeline.with_css_transform(transform);
+    }
 
     // Load theme CSS from the project (if available)
     let theme_css = theme_css::load_theme_css(&config.root_dir);

--- a/native/vtz/src/server/module_server.rs
+++ b/native/vtz/src/server/module_server.rs
@@ -2143,16 +2143,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_source_file_css_runs_postcss_when_config_exists() {
+        use crate::compiler::postcss::{find_postcss_config, PostCssCssTransform};
+
         let tmp = tempfile::tempdir().unwrap();
-        let state = create_test_state(tmp.path());
         let node_modules = tmp.path().join("node_modules");
+        let src_dir = tmp.path().join("src");
+        let deps_dir = tmp.path().join(".vertz/deps");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::create_dir_all(&deps_dir).unwrap();
         std::fs::create_dir_all(node_modules.join("postcss")).unwrap();
         std::fs::create_dir_all(node_modules.join("fake-prefixer")).unwrap();
-        std::fs::write(
-            tmp.path().join("src/styles.css"),
-            "body { display: flex; }\n",
-        )
-        .unwrap();
+        std::fs::write(src_dir.join("styles.css"), "body { display: flex; }\n").unwrap();
         std::fs::write(
             tmp.path().join("postcss.config.js"),
             "module.exports = { plugins: { 'fake-prefixer': {} } };",
@@ -2191,6 +2192,37 @@ mod tests {
         )
         .unwrap();
 
+        let config_path = find_postcss_config(tmp.path()).expect("config should exist");
+        let transform = Arc::new(PostCssCssTransform::new(config_path));
+        let pipeline =
+            CompilationPipeline::new(tmp.path().to_path_buf(), src_dir.clone(), test_plugin())
+                .with_css_transform(transform);
+
+        let state = Arc::new(DevServerState {
+            plugin: test_plugin(),
+            pipeline,
+            root_dir: tmp.path().to_path_buf(),
+            src_dir: src_dir.clone(),
+            entry_file: src_dir.join("app.tsx"),
+            deps_dir,
+            theme_css: None,
+            hmr_hub: HmrHub::new(),
+            module_graph: crate::watcher::new_shared_module_graph(),
+            error_broadcaster: ErrorBroadcaster::new(),
+            console_log: ConsoleLog::new(),
+            mcp_sessions: McpSessions::new(),
+            mcp_event_hub: crate::server::mcp_events::McpEventHub::new(),
+            start_time: std::time::Instant::now(),
+            enable_ssr: false,
+            port: 3000,
+            typecheck_enabled: false,
+            api_isolate: Arc::new(std::sync::RwLock::new(None)),
+            auto_install: false,
+            auto_install_lock: Arc::new(tokio::sync::Mutex::new(())),
+            auto_install_inflight: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            auto_install_failed: Arc::new(std::sync::Mutex::new(HashSet::new())),
+        });
+
         let req = Request::builder()
             .uri("/src/styles.css")
             .body(Body::empty())
@@ -2208,12 +2240,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_source_file_css_postcss_error_reports_overlay_error() {
+        use crate::compiler::postcss::{find_postcss_config, PostCssCssTransform};
+
         let tmp = tempfile::tempdir().unwrap();
-        let state = create_test_state(tmp.path());
         let node_modules = tmp.path().join("node_modules");
+        let src_dir = tmp.path().join("src");
+        let deps_dir = tmp.path().join(".vertz/deps");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::create_dir_all(&deps_dir).unwrap();
         std::fs::create_dir_all(node_modules.join("postcss")).unwrap();
         std::fs::create_dir_all(node_modules.join("broken-plugin")).unwrap();
-        std::fs::write(tmp.path().join("src/styles.css"), "@broken;\n").unwrap();
+        std::fs::write(src_dir.join("styles.css"), "@broken;\n").unwrap();
         std::fs::write(
             tmp.path().join("postcss.config.js"),
             "module.exports = { plugins: { 'broken-plugin': {} } };",
@@ -2256,6 +2293,37 @@ mod tests {
 };"#,
         )
         .unwrap();
+
+        let config_path = find_postcss_config(tmp.path()).expect("config should exist");
+        let transform = Arc::new(PostCssCssTransform::new(config_path));
+        let pipeline =
+            CompilationPipeline::new(tmp.path().to_path_buf(), src_dir.clone(), test_plugin())
+                .with_css_transform(transform);
+
+        let state = Arc::new(DevServerState {
+            plugin: test_plugin(),
+            pipeline,
+            root_dir: tmp.path().to_path_buf(),
+            src_dir: src_dir.clone(),
+            entry_file: src_dir.join("app.tsx"),
+            deps_dir,
+            theme_css: None,
+            hmr_hub: HmrHub::new(),
+            module_graph: crate::watcher::new_shared_module_graph(),
+            error_broadcaster: ErrorBroadcaster::new(),
+            console_log: ConsoleLog::new(),
+            mcp_sessions: McpSessions::new(),
+            mcp_event_hub: crate::server::mcp_events::McpEventHub::new(),
+            start_time: std::time::Instant::now(),
+            enable_ssr: false,
+            port: 3000,
+            typecheck_enabled: false,
+            api_isolate: Arc::new(std::sync::RwLock::new(None)),
+            auto_install: false,
+            auto_install_lock: Arc::new(tokio::sync::Mutex::new(())),
+            auto_install_inflight: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            auto_install_failed: Arc::new(std::sync::Mutex::new(HashSet::new())),
+        });
 
         let req = Request::builder()
             .uri("/src/styles.css")


### PR DESCRIPTION
## Summary

- Introduces a `CssTransform` trait (`compiler/css_transform.rs`) as an extension point for CSS processing in the compilation pipeline
- Adds `PostCssCssTransform` in `postcss.rs` that wraps existing PostCSS logic behind the new trait
- Removes all direct `postcss::*` calls from `pipeline.rs` — PostCSS is now wired during pipeline construction in `http.rs`
- Updates all PostCSS-related tests in `pipeline.rs` and `module_server.rs` to explicitly wire the transform

## Test plan

- [x] New unit tests for custom CSS transform hook (success + error paths)
- [x] Existing PostCSS integration tests updated and passing
- [x] Full quality gates pass (`cargo test --all && cargo clippy --all-targets --release -- -D warnings && cargo fmt --all -- --check`)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)