### PR TITLE
fix(ci): only create GitHub release when changesets publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
 
       - name: Create or update GitHub Release
+        if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

- Gate the "Create or update GitHub Release" step on `steps.changesets.outputs.published == 'true'` so it only runs when the Version PR is merged and `version.txt` is already correct in the commit

## Problem

The release step ran on **every push to main**, even when changesets only created a Version PR (didn't publish). The `version.sh` script bumps `version.txt` locally during the job, so the release tag picked up the new version — but binaries were compiled in a prior job using the **old** `version.txt` from the commit.

This caused v0.0.3 to ship with a binary reporting `vtz 0.0.1`.

## Fix

One-line condition: `if: steps.changesets.outputs.published == 'true'`

The release step already deletes and recreates releases for the same tag, so once this fix lands and Version PR #56 is merged, the stale v0.0.3 release will be replaced with correctly versioned binaries.

## Test plan

- [ ] Merge this PR
- [ ] Merge Version PR #56 (`changeset-release/main`)
- [ ] Verify the release workflow creates v0.0.3 with a binary that reports `vtz 0.0.3`
- [ ] Verify `curl -fsSL .../install.sh | sh` installs 0.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)