### PR TITLE
fix(vtz): rebuild binary when VERTZ_VERSION env var changes

### DIFF
--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -4163,7 +4163,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vertz-compiler"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "napi",
  "napi-build",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "vertz-compiler-core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -4195,7 +4195,7 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtz"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "async-recursion",
  "axum",

--- a/native/vtz/build.rs
+++ b/native/vtz/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Ensure Cargo rebuilds when VERTZ_VERSION changes (used by option_env! in cli.rs)
+    println!("cargo:rerun-if-env-changed=VERTZ_VERSION");
+}


### PR DESCRIPTION
Adds `build.rs` with `cargo:rerun-if-env-changed=VERTZ_VERSION` so Cargo recompiles the vtz crate when the version env var changes. Without this, `option_env!("VERTZ_VERSION")` in `cli.rs` kept returning a stale cached value across CI runs, causing every release binary to report `vtz 0.0.1` regardless of the actual version. The Cargo.lock changes are version bumps from the latest version.sh run.