### PR TITLE
fix(ci): always upload fresh binaries to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: native
-
       - name: Determine version
         id: version
         run: |
@@ -58,6 +54,12 @@ jobs:
           else
             echo "version=0.0.1" >> "$GITHUB_OUTPUT"
           fi
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native
+          # Include version in cache key so env-dependent builds are never stale
+          key: v${{ steps.version.outputs.version }}
 
       - name: Build runtime binary
         working-directory: native
@@ -70,10 +72,19 @@ jobs:
           cp native/target/${{ matrix.target }}/release/vtz npm/${{ matrix.pkg }}/vtz
           chmod +x npm/${{ matrix.pkg }}/vtz
 
-      - name: Verify binary
+      - name: Verify binary version matches version.txt
         run: |
+          EXPECTED="vtz ${{ steps.version.outputs.version }}"
           if [ "$(uname -m)" = "${{ matrix.expected_arch }}" ]; then
-            npm/${{ matrix.pkg }}/vtz --version || true
+            ACTUAL=$(npm/${{ matrix.pkg }}/vtz --version 2>&1)
+            echo "Expected: $EXPECTED"
+            echo "Actual:   $ACTUAL"
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error::Binary version mismatch! Expected '$EXPECTED' but got '$ACTUAL'"
+              exit 1
+            fi
+          else
+            echo "Cross-compiled binary, skipping runtime version check"
           fi
 
       - uses: actions/upload-artifact@v4
@@ -146,8 +157,7 @@ jobs:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 
-      - name: Create or update GitHub Release
-        if: steps.changesets.outputs.published == 'true'
+      - name: Upload binaries to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -168,14 +178,17 @@ jobs:
             exit 0
           fi
 
-          # Delete existing release for this version so we can recreate with fresh binaries
           if gh release view "$TAG" &>/dev/null; then
-            echo "Release $TAG exists, updating with new binaries..."
-            gh release delete "$TAG" --yes
-            git push origin --delete "$TAG" 2>/dev/null || true
+            # Release exists — delete old binary assets and upload fresh ones
+            echo "Release $TAG exists, replacing binary assets..."
+            for asset in "${ASSETS[@]}"; do
+              gh release delete-asset "$TAG" "$asset" --yes 2>/dev/null || true
+            done
+            gh release upload "$TAG" "${ASSETS[@]}"
+          else
+            # First release for this version — create it
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              "${ASSETS[@]}"
           fi
-
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            "${ASSETS[@]}"


### PR DESCRIPTION
## Summary

- **Root cause:** The `install.sh` downloads from `/releases/latest/download/`, but the release workflow only uploaded binaries gated on `steps.changesets.outputs.published == 'true'`. After the `build.rs` fix (PR #68), new correct binaries were built but never uploaded because no changeset triggered a publish. The v0.0.3 release still had 0.0.1-baked binaries.
- **Fix:** Remove the changesets gate from binary upload — binaries are now uploaded on **every push to main**, replacing stale assets via `gh release delete-asset` + `gh release upload`
- **Safety net 1:** The verify step now **asserts** `--version` output matches `version.txt` and **fails the build** on mismatch (was previously `|| true`)
- **Safety net 2:** Rust cache key now includes the version, so a version bump always gets a fresh build even if cargo fingerprinting misses it

## Test plan

- [ ] Merge this PR → Release workflow runs → verify step passes (binary reports correct version)
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/vertz-dev/vtz/main/install.sh | sh` → should show `vtz 0.0.3`
- [ ] Confirm `gh release view v0.0.3 --json assets` shows fresh upload timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)