### PR TITLE
ci: add macOS Intel (x86_64) to release build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,10 @@ jobs:
             os: macos-14
             pkg: runtime-darwin-arm64
             expected_arch: arm64
-          # darwin-x64 deferred (V8 cross-compile issue)
+          - target: x86_64-apple-darwin
+            os: macos-13
+            pkg: runtime-darwin-x64
+            expected_arch: x86_64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
             pkg: runtime-linux-x64
@@ -115,6 +118,13 @@ jobs:
         with:
           name: runtime-darwin-arm64
           path: npm/runtime-darwin-arm64/
+        continue-on-error: true
+
+      - name: Download darwin-x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: runtime-darwin-x64
+          path: npm/runtime-darwin-x64/
         continue-on-error: true
 
       - name: Download linux-x64 binary


### PR DESCRIPTION
## Summary

Adds `x86_64-apple-darwin` to the release workflow build matrix using a native `macos-13` Intel runner. This avoids the V8 cross-compile issue that previously blocked darwin-x64 builds. The npm package (`@vertz/runtime-darwin-x64`) and runtime selector wiring were already in place — only the CI pipeline needed updating.

## Changes

- Added darwin-x64 matrix entry (`macos-13` runner) to `build-binaries` job
- Added artifact download step for `runtime-darwin-x64` in the `release` job

## Test plan

- [ ] Verify `macos-13` runner builds `x86_64-apple-darwin` target successfully
- [ ] Verify binary is included in npm publish and GitHub release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)