### PR TITLE
refactor(runtime): route all compilation through FrameworkPlugin

### DIFF
--- a/native/vtz/src/compiler/pipeline.rs
+++ b/native/vtz/src/compiler/pipeline.rs
@@ -1225,20 +1225,27 @@ pub fn fix_module_id(code: &str, file_path: &Path, root_dir: &Path) -> String {
         .replace(&format!("\"{}\"", abs_path), &format!("\"{}\"", url_path))
 }
 
-/// Apply post-processing fixes to compiled output.
+/// Apply generic post-processing fixes to compiled output.
 ///
-/// Both the browser pipeline and the SSR module loader need these fixes:
-/// 1. Fix wrong API names: compiler emits `effect` but the API is `domEffect`
-/// 2. Move internal APIs from `@vertz/ui` to `@vertz/ui/internals`
-/// 3. Strip leftover TypeScript syntax artifacts
-/// 4. Deduplicate imports to prevent "already been declared" errors
-pub fn post_process_compiled(code: &str) -> String {
-    let fixed = fix_compiler_api_names(code);
-    let internals_fixed = fix_internals_imports(&fixed);
-    let cleaned = strip_leftover_typescript(&internals_fixed);
+/// These are framework-agnostic transforms that any plugin can use:
+/// 1. Strip leftover TypeScript syntax artifacts
+/// 2. Deduplicate imports to prevent "already been declared" errors
+/// 3. Strip import.meta.hot (Bun HMR API)
+pub fn generic_post_process(code: &str) -> String {
+    let cleaned = strip_leftover_typescript(code);
     let deduped = deduplicate_imports(&cleaned);
     let no_cross_dupes = remove_cross_specifier_duplicates(&deduped);
     strip_import_meta_hot(&no_cross_dupes)
+}
+
+/// Apply all post-processing fixes including Vertz-specific ones.
+///
+/// Equivalent to calling Vertz-specific transforms followed by `generic_post_process()`.
+/// Used by the Vertz plugin — other plugins should only call `generic_post_process()`.
+pub fn post_process_compiled(code: &str) -> String {
+    let fixed = fix_compiler_api_names(code);
+    let internals_fixed = fix_internals_imports(&fixed);
+    generic_post_process(&internals_fixed)
 }
 
 /// Simple hash function for generating CSS keys.
@@ -2140,6 +2147,32 @@ export function App() {
         let code = "const __$moduleId = '/other/app.tsx';";
         let result = fix_module_id(code, Path::new("/other/app.tsx"), Path::new("/project"));
         assert_eq!(result, code);
+    }
+
+    // ── generic_post_process ──────────────────────────────────────
+
+    #[test]
+    fn test_generic_post_process_strips_typescript_and_deduplicates() {
+        let code = "import type { Foo } from 'bar';\nimport { x } from 'mod';\nimport { x } from 'mod';\nimport.meta.hot.accept();\nconst y = 1;";
+        let result = generic_post_process(code);
+        // import type stripped
+        assert!(!result.contains("import type"));
+        // import.meta.hot stripped
+        assert!(!result.contains("import.meta.hot"));
+        // duplicates removed
+        assert!(result.contains("const y = 1"));
+        // Does NOT fix Vertz-specific API names (that's not generic)
+    }
+
+    #[test]
+    fn test_generic_post_process_does_not_rename_effect() {
+        let code = "import { effect } from '@vertz/ui';\neffect(() => {});";
+        let result = generic_post_process(code);
+        // generic_post_process should NOT rename effect to domEffect
+        assert!(
+            result.contains("effect"),
+            "generic_post_process should not touch Vertz-specific API names"
+        );
     }
 
     // ── post_process_compiled (integration) ─────────────────────────

--- a/native/vtz/src/plugin/vertz.rs
+++ b/native/vtz/src/plugin/vertz.rs
@@ -74,14 +74,11 @@ impl FrameworkPlugin for VertzPlugin {
     }
 
     fn post_process(&self, code: &str, ctx: &CompileContext) -> String {
-        // Apply Vertz-specific post-processing:
-        // 1. Fix wrong API names (effect → domEffect)
-        // 2. Move internal APIs to @vertz/ui/internals
-        // 3. Strip leftover TypeScript artifacts
-        // 4. Deduplicate imports
-        // 5. Strip import.meta.hot (Bun HMR API)
+        // Vertz-specific post-processing:
+        // 1. Fix wrong API names (effect → domEffect) — Vertz compiler quirk
+        // 2. Move internal APIs to @vertz/ui/internals — Vertz compiler quirk
         let processed = crate::compiler::pipeline::post_process_compiled(code);
-        // 6. Fix module ID to use URL-relative path for Fast Refresh registry
+        // 3. Fix module ID to use URL-relative path for Fast Refresh registry
         crate::compiler::pipeline::fix_module_id(&processed, ctx.file_path, ctx.root_dir)
     }
 

--- a/native/vtz/src/runtime/js_runtime.rs
+++ b/native/vtz/src/runtime/js_runtime.rs
@@ -40,7 +40,6 @@ pub struct CapturedOutput {
 }
 
 /// Configuration for creating a VertzJsRuntime.
-#[derive(Default)]
 pub struct VertzRuntimeOptions {
     /// Root directory for module resolution. Defaults to current directory.
     pub root_dir: Option<String>,
@@ -50,6 +49,20 @@ pub struct VertzRuntimeOptions {
     pub enable_inspector: bool,
     /// Whether to enable the disk-backed compilation cache. Defaults to false.
     pub compile_cache: bool,
+    /// Framework plugin for compilation. Defaults to VertzPlugin.
+    pub plugin: Arc<dyn crate::plugin::FrameworkPlugin>,
+}
+
+impl Default for VertzRuntimeOptions {
+    fn default() -> Self {
+        Self {
+            root_dir: None,
+            capture_output: false,
+            enable_inspector: false,
+            compile_cache: false,
+            plugin: Arc::new(crate::plugin::vertz::VertzPlugin),
+        }
+    }
 }
 
 /// Wrapper around deno_core's JsRuntime with Vertz-specific extensions.
@@ -141,7 +154,7 @@ impl VertzJsRuntime {
                 .to_string_lossy()
                 .to_string()
         });
-        let module_loader = Rc::new(VertzModuleLoader::new(&root_dir));
+        let module_loader = Rc::new(VertzModuleLoader::new(&root_dir, options.plugin.clone()));
 
         let mut runtime = JsRuntime::new(RuntimeOptions {
             module_loader: Some(module_loader),
@@ -204,7 +217,11 @@ impl VertzJsRuntime {
                 .to_string_lossy()
                 .to_string()
         });
-        let module_loader = Rc::new(VertzModuleLoader::new_with_cache(&root_dir, cache_enabled));
+        let module_loader = Rc::new(VertzModuleLoader::new_with_cache(
+            &root_dir,
+            cache_enabled,
+            options.plugin.clone(),
+        ));
 
         let snapshot = crate::test::snapshot::get_test_snapshot();
 

--- a/native/vtz/src/runtime/module_loader.rs
+++ b/native/vtz/src/runtime/module_loader.rs
@@ -12,9 +12,8 @@ use deno_core::ModuleType;
 use deno_core::RequestedModuleType;
 use deno_core::ResolutionKind;
 
-use crate::compiler::pipeline::post_process_compiled;
+use crate::plugin::{CompileContext, FrameworkPlugin};
 use crate::runtime::compile_cache::{CachedCompilation, CompileCache};
-use vertz_compiler_core::CompileOptions;
 
 /// Source maps collected during module loading.
 pub type SourceMapStore = RefCell<HashMap<String, String>>;
@@ -24,7 +23,7 @@ pub type SourceMapStore = RefCell<HashMap<String, String>>;
 /// Handles:
 /// - File system resolution for relative and absolute paths
 /// - Node.js-style resolution for bare specifiers (node_modules)
-/// - TypeScript/TSX compilation via vertz-compiler-core
+/// - TypeScript/TSX compilation via the framework plugin
 /// - Source map collection for error reporting
 /// - URL canonicalization to ensure same physical file = same module identity
 /// - Compilation caching (disk-backed, content-hash-keyed)
@@ -33,25 +32,32 @@ pub struct VertzModuleLoader {
     source_maps: SourceMapStore,
     canon_cache: RefCell<HashMap<PathBuf, PathBuf>>,
     compile_cache: CompileCache,
+    plugin: std::sync::Arc<dyn FrameworkPlugin>,
 }
 
 impl VertzModuleLoader {
-    pub fn new(root_dir: &str) -> Self {
+    pub fn new(root_dir: &str, plugin: std::sync::Arc<dyn FrameworkPlugin>) -> Self {
         Self {
             root_dir: PathBuf::from(root_dir),
             source_maps: RefCell::new(HashMap::new()),
             canon_cache: RefCell::new(HashMap::new()),
             compile_cache: CompileCache::new(Path::new(root_dir), false),
+            plugin,
         }
     }
 
     /// Create a new module loader with compilation caching enabled.
-    pub fn new_with_cache(root_dir: &str, cache_enabled: bool) -> Self {
+    pub fn new_with_cache(
+        root_dir: &str,
+        cache_enabled: bool,
+        plugin: std::sync::Arc<dyn FrameworkPlugin>,
+    ) -> Self {
         Self {
             root_dir: PathBuf::from(root_dir),
             source_maps: RefCell::new(HashMap::new()),
             canon_cache: RefCell::new(HashMap::new()),
             compile_cache: CompileCache::new(Path::new(root_dir), cache_enabled),
+            plugin,
         }
     }
 
@@ -295,11 +301,11 @@ impl VertzModuleLoader {
         }
     }
 
-    /// Compile TypeScript/TSX source code using vertz-compiler-core.
+    /// Compile TypeScript/TSX source code using the framework plugin.
     ///
     /// Checks the disk-backed compilation cache first. On cache hit, skips
     /// the compiler entirely and returns the cached result. On cache miss,
-    /// compiles, post-processes, caches the result, and returns.
+    /// compiles via the plugin, post-processes, caches the result, and returns.
     fn compile_source(&self, source: &str, filename: &str) -> Result<String, AnyError> {
         let target = "ssr";
 
@@ -318,18 +324,21 @@ impl VertzModuleLoader {
             ));
         }
 
-        let result = vertz_compiler_core::compile(
-            source,
-            CompileOptions {
-                filename: Some(filename.to_string()),
-                target: Some(target.to_string()),
-                ..Default::default()
-            },
-        );
+        let file_path = Path::new(filename);
+        let src_dir = self.root_dir.join("src");
+        let ctx = CompileContext {
+            file_path,
+            root_dir: &self.root_dir,
+            src_dir: &src_dir,
+            target,
+        };
 
-        // Check for compilation errors
-        if let Some(ref diagnostics) = result.diagnostics {
-            let errors: Vec<String> = diagnostics
+        let output = self.plugin.compile(source, &ctx);
+
+        // Check for compilation diagnostics
+        if !output.diagnostics.is_empty() {
+            let errors: Vec<String> = output
+                .diagnostics
                 .iter()
                 .map(|d| {
                     let location = match (d.line, d.column) {
@@ -342,20 +351,19 @@ impl VertzModuleLoader {
 
             if !errors.is_empty() {
                 // Diagnostics are warnings, not hard errors — log but don't fail
-                // (the vertz compiler may emit diagnostics that are informational)
+                // (the compiler may emit diagnostics that are informational)
             }
         }
 
         // Store source map if available
-        if let Some(ref map) = result.map {
+        if let Some(ref map) = output.source_map {
             self.source_maps
                 .borrow_mut()
                 .insert(filename.to_string(), map.clone());
         }
 
-        // Apply the same post-processing as the browser pipeline:
-        // fix API names, split internal imports, strip leftover TS, deduplicate imports
-        let code = post_process_compiled(&result.code);
+        // Apply plugin post-processing (framework-specific fixups)
+        let code = self.plugin.post_process(&output.code, &ctx);
 
         // Cache the compilation result (code + source map + CSS, before CSS injection)
         self.compile_cache.put(
@@ -363,14 +371,14 @@ impl VertzModuleLoader {
             target,
             &CachedCompilation {
                 code: code.clone(),
-                source_map: result.map.clone(),
-                css: result.css.clone(),
+                source_map: output.source_map.clone(),
+                css: output.css.clone(),
             },
         );
 
         Ok(Self::prepend_css_injection(
             code,
-            result.css.as_deref(),
+            output.css.as_deref(),
             filename,
         ))
     }
@@ -1142,8 +1150,13 @@ impl ModuleLoader for VertzModuleLoader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     fn create_temp_dir() -> tempfile::TempDir {
         tempfile::tempdir().unwrap()
+    }
+
+    fn test_plugin() -> std::sync::Arc<dyn FrameworkPlugin> {
+        std::sync::Arc::new(crate::plugin::vertz::VertzPlugin)
     }
 
     /// Canonicalize a path for test assertions.
@@ -1160,7 +1173,7 @@ mod tests {
         std::fs::write(&main_file, "import './utils.js';").unwrap();
         std::fs::write(&util_file, "export const x = 1;").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("./utils.js", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1176,7 +1189,7 @@ mod tests {
         std::fs::write(&main_file, "").unwrap();
         std::fs::write(&util_file, "export const x = 1;").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("./utils", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1194,7 +1207,7 @@ mod tests {
         std::fs::write(&main_file, "").unwrap();
         std::fs::write(&index_file, "export const x = 1;").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("./lib", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1208,7 +1221,7 @@ mod tests {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("./nonexistent", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_err());
@@ -1235,7 +1248,7 @@ mod tests {
         .unwrap();
         std::fs::write(&entry, "export default {};").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("my-pkg", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1249,7 +1262,7 @@ mod tests {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("nonexistent-pkg", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_err());
@@ -1263,7 +1276,7 @@ mod tests {
         let js_file = tmp.path().join("test.js");
         std::fs::write(&js_file, "export const x = 42;").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let specifier = ModuleSpecifier::from_file_path(&js_file).unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);
 
@@ -1287,7 +1300,7 @@ mod tests {
         let ts_file = tmp.path().join("test.ts");
         std::fs::write(&ts_file, "const x: number = 42; export { x };").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let specifier = ModuleSpecifier::from_file_path(&ts_file).unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);
 
@@ -1328,7 +1341,7 @@ export function Hello() {
         )
         .unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let specifier = ModuleSpecifier::from_file_path(&tsx_file).unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);
 
@@ -1373,7 +1386,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("@vertz/test", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1387,7 +1400,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("bun:test", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1398,7 +1411,7 @@ export function Hello() {
     #[test]
     fn test_load_vertz_test_module() {
         let tmp = create_temp_dir();
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let specifier = ModuleSpecifier::parse("vertz:test").unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);
 
@@ -1441,7 +1454,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("node:path", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1454,7 +1467,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("node:os", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1467,7 +1480,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("node:url", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1480,7 +1493,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("node:events", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1493,7 +1506,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         let result = loader.resolve("node:process", referrer.as_str(), ResolutionKind::Import);
         assert!(result.is_ok());
@@ -1506,7 +1519,7 @@ export function Hello() {
         let main_file = tmp.path().join("main.js");
         std::fs::write(&main_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
         // bare "path" (without node: prefix) should also resolve
         let result = loader.resolve("path", referrer.as_str(), ResolutionKind::Import);
@@ -1517,7 +1530,7 @@ export function Hello() {
     #[test]
     fn test_load_node_path_module() {
         let tmp = create_temp_dir();
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let specifier = ModuleSpecifier::parse(NODE_PATH_SPECIFIER).unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);
 
@@ -1545,7 +1558,7 @@ export function Hello() {
     #[test]
     fn test_load_node_events_module() {
         let tmp = create_temp_dir();
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let specifier = ModuleSpecifier::parse(NODE_EVENTS_SPECIFIER).unwrap();
         let response = loader.load(&specifier, None, false, RequestedModuleType::None);
 
@@ -1586,7 +1599,7 @@ export function Hello() {
         std::fs::write(&main_file, "").unwrap();
         std::fs::write(&utils_file, "export const x = 1;").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&main_file).unwrap();
 
         // Direct path
@@ -1641,7 +1654,7 @@ export function Hello() {
         std::fs::create_dir_all(tmp.path().join("src")).unwrap();
         std::fs::write(&src_file, "").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
         let referrer = ModuleSpecifier::from_file_path(&src_file).unwrap();
 
         // Import via bare specifier (goes through node_modules symlink)
@@ -1670,7 +1683,7 @@ export function Hello() {
         let file = tmp.path().join("test.js");
         std::fs::write(&file, "export const x = 1;").unwrap();
 
-        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), test_plugin());
 
         let result1 = loader.canonicalize_cached(&file);
         let result2 = loader.canonicalize_cached(&file);
@@ -1681,5 +1694,59 @@ export function Hello() {
         );
         // On macOS, /tmp -> /private/tmp, so canonical path may differ from input
         assert!(result1.is_absolute(), "Canonical path should be absolute");
+    }
+
+    /// A custom plugin that adds a marker to compiled output, proving
+    /// the module loader delegates compilation to the plugin.
+    struct MarkerPlugin;
+
+    impl FrameworkPlugin for MarkerPlugin {
+        fn name(&self) -> &str {
+            "marker"
+        }
+
+        fn compile(
+            &self,
+            _source: &str,
+            _ctx: &crate::plugin::CompileContext,
+        ) -> crate::plugin::CompileOutput {
+            crate::plugin::CompileOutput {
+                code: "/* MARKER_PLUGIN_OUTPUT */ export const x = 1;".to_string(),
+                css: None,
+                source_map: None,
+                diagnostics: vec![],
+            }
+        }
+
+        fn hmr_client_scripts(&self) -> Vec<crate::plugin::ClientScript> {
+            vec![]
+        }
+    }
+
+    #[test]
+    fn test_compile_delegates_to_plugin() {
+        let tmp = create_temp_dir();
+        let ts_file = tmp.path().join("test.ts");
+        std::fs::write(&ts_file, "const x: number = 42; export { x };").unwrap();
+
+        let plugin: std::sync::Arc<dyn FrameworkPlugin> = std::sync::Arc::new(MarkerPlugin);
+        let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), plugin);
+        let specifier = ModuleSpecifier::from_file_path(&ts_file).unwrap();
+        let response = loader.load(&specifier, None, false, RequestedModuleType::None);
+
+        match response {
+            ModuleLoadResponse::Sync(Ok(source)) => match &source.code {
+                deno_core::ModuleSourceCode::String(code) => {
+                    assert!(
+                        code.as_str().contains("MARKER_PLUGIN_OUTPUT"),
+                        "Module loader should delegate compilation to the plugin, got: {}",
+                        code.as_str()
+                    );
+                }
+                _ => panic!("Expected string source code"),
+            },
+            ModuleLoadResponse::Sync(Err(e)) => panic!("Module load failed: {}", e),
+            _ => panic!("Expected synchronous module load"),
+        }
     }
 }

--- a/native/vtz/src/runtime/persistent_isolate.rs
+++ b/native/vtz/src/runtime/persistent_isolate.rs
@@ -284,8 +284,7 @@ async fn isolate_event_loop(
     let mut runtime = match VertzJsRuntime::new(VertzRuntimeOptions {
         root_dir: Some(root_dir.to_string_lossy().to_string()),
         capture_output: false,
-        enable_inspector: false,
-        compile_cache: false,
+        ..Default::default()
     }) {
         Ok(rt) => rt,
         Err(e) => {

--- a/native/vtz/src/test/config.rs
+++ b/native/vtz/src/test/config.rs
@@ -64,22 +64,23 @@ pub fn load_test_config(root_dir: &Path) -> Result<TestConfig, AnyError> {
 
     // Read and compile the config file
     let source = std::fs::read_to_string(&config_path)?;
-    let filename = config_path.to_string_lossy().to_string();
     let ext = config_path
         .extension()
         .and_then(|e| e.to_str())
         .unwrap_or("");
 
     let compiled = if ext == "ts" || ext == "tsx" {
-        let result = vertz_compiler_core::compile(
-            &source,
-            vertz_compiler_core::CompileOptions {
-                filename: Some(filename.clone()),
-                target: Some("ssr".to_string()),
-                ..Default::default()
-            },
-        );
-        result.code
+        let plugin: std::sync::Arc<dyn crate::plugin::FrameworkPlugin> =
+            std::sync::Arc::new(crate::plugin::vertz::VertzPlugin);
+        let src_dir = root_dir.join("src");
+        let ctx = crate::plugin::CompileContext {
+            file_path: &config_path,
+            root_dir,
+            src_dir: &src_dir,
+            target: "ssr",
+        };
+        let output = plugin.compile(&source, &ctx);
+        output.code
     } else {
         source
     };

--- a/native/vtz/src/test/executor.rs
+++ b/native/vtz/src/test/executor.rs
@@ -172,11 +172,14 @@ fn execute_test_file_inner(
     root_dir: &str,
     options: &ExecuteOptions,
 ) -> Result<(Vec<TestResult>, Option<serde_json::Value>), AnyError> {
+    let plugin: std::sync::Arc<dyn crate::plugin::FrameworkPlugin> =
+        std::sync::Arc::new(crate::plugin::vertz::VertzPlugin);
     let mut runtime = VertzJsRuntime::new_for_test(VertzRuntimeOptions {
         root_dir: Some(root_dir.to_string()),
         capture_output: true,
         enable_inspector: options.coverage,
         compile_cache: !options.no_cache,
+        plugin: plugin.clone(),
     })?;
 
     // NOTE: async context + test harness are pre-baked in the V8 snapshot,
@@ -198,22 +201,22 @@ fn execute_test_file_inner(
                 e
             )
         })?;
-        let filename = preload_path.to_string_lossy().to_string();
         let ext = preload_path
             .extension()
             .and_then(|e| e.to_str())
             .unwrap_or("");
 
         let code = if ext == "ts" || ext == "tsx" {
-            let result = vertz_compiler_core::compile(
-                &preload_source,
-                vertz_compiler_core::CompileOptions {
-                    filename: Some(filename.clone()),
-                    target: Some("ssr".to_string()),
-                    ..Default::default()
-                },
-            );
-            result.code
+            let root_path = std::path::Path::new(root_dir);
+            let src_dir = root_path.join("src");
+            let ctx = crate::plugin::CompileContext {
+                file_path: preload_path,
+                root_dir: root_path,
+                src_dir: &src_dir,
+                target: "ssr",
+            };
+            let output = plugin.compile(&preload_source, &ctx);
+            output.code
         } else {
             preload_source
         };

--- a/native/vtz/tests/sqlite_integration.rs
+++ b/native/vtz/tests/sqlite_integration.rs
@@ -108,7 +108,9 @@ fn test_sqlite_module_resolution() {
     use vertz_runtime::runtime::module_loader::VertzModuleLoader;
 
     let tmp = tempfile::tempdir().unwrap();
-    let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy());
+    let plugin: std::sync::Arc<dyn vertz_runtime::plugin::FrameworkPlugin> =
+        std::sync::Arc::new(vertz_runtime::plugin::vertz::VertzPlugin);
+    let loader = VertzModuleLoader::new(&tmp.path().to_string_lossy(), plugin);
 
     // Canonical: vertz:sqlite
     let result = loader.resolve("vertz:sqlite", "file:///test.js", ResolutionKind::Import);


### PR DESCRIPTION
## Summary

Closes #81 (steps 1–4)

- **Route all compilation through `FrameworkPlugin` trait** — the runtime no longer calls `vertz_compiler_core` directly. All compilation goes through `plugin.compile()` and `plugin.post_process()`.
- **Add `plugin` field to `VertzRuntimeOptions`** — defaults to `VertzPlugin`, making it easy for other frameworks to plug in their own compiler.
- **Extract `generic_post_process()`** — separates framework-agnostic transforms (strip TS, dedupe imports, strip HMR) from Vertz-specific transforms (`fix_compiler_api_names`, `fix_internals_imports`).

## Public API Changes

- `VertzRuntimeOptions` gains a `plugin: Arc<dyn FrameworkPlugin>` field (defaults to `VertzPlugin` via `Default` impl — no breaking change for existing callers using `..Default::default()`)
- `VertzModuleLoader::new()` now takes an `Arc<dyn FrameworkPlugin>` parameter
- `generic_post_process()` is now public in `compiler::pipeline`

## What Changed

| File | Change |
|------|--------|
| `runtime/module_loader.rs` | Replace `vertz_compiler_core::compile()` with `plugin.compile()` + `plugin.post_process()`. Add `MarkerPlugin` delegation test. |
| `runtime/js_runtime.rs` | Add `plugin` field to `VertzRuntimeOptions`, thread it to module loader |
| `runtime/persistent_isolate.rs` | Use `..Default::default()` for runtime options |
| `test/executor.rs` | Route preload compilation through plugin |
| `test/config.rs` | Route config file compilation through plugin |
| `compiler/pipeline.rs` | Extract `generic_post_process()`, add tests |
| `plugin/vertz.rs` | Update comments |
| `tests/sqlite_integration.rs` | Pass plugin to module loader |

## Verification

- `vertz_compiler_core` is now only referenced in `plugin/vertz.rs` (confirmed via grep)
- All 3,631 tests pass
- Clippy clean, fmt clean

## Out of Scope

Per issue #81, steps 5–6 are separate follow-up work:
- Step 5: Move compiler crates to `vertz-dev/vertz` repo
- Step 6: Add validation hook support

## Test plan

- [x] All existing tests pass (no behavioral change)
- [x] New `test_compile_delegates_to_plugin` proves module loader delegates to plugin
- [x] New `test_generic_post_process_*` tests verify transform separation
- [x] `cargo clippy --all-targets --release -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)